### PR TITLE
Allow memory display configuration per memory view instance

### DIFF
--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -69,3 +69,12 @@
   width: 100%;
   font-weight: bold;
 }
+
+.reset-advanced-options-icon {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+}

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -16,17 +16,16 @@
 
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { NotificationType, RequestType } from 'vscode-messenger-common';
+import { MemoryDisplayConfiguration } from '../webview/utils/view-types';
 import type { VariableRange } from './memory-range';
-import { ColumnVisibilityStatus, MemoryDisplayConfiguration, MemoryDisplayConfigurationChangeRequest } from '../webview/utils/view-types';
 
 export type MemoryReadResult = DebugProtocol.ReadMemoryResponse['body'];
 export type MemoryWriteResult = DebugProtocol.WriteMemoryResponse['body'];
 
 export const readyType: NotificationType<void> = { method: 'ready' };
 export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
-export const setMemoryDisplayConfigurationType: NotificationType<MemoryDisplayConfigurationChangeRequest> = { method: 'setMemoryDisplayConfiguration' };
-export const memoryDisplayConfigurationChangedType: NotificationType<MemoryDisplayConfiguration> = { method: 'memoryDisplayConfigurationChanged' };
-export const columnVisibilityType: NotificationType<ColumnVisibilityStatus> = { method: 'columnVisibility' };
+export const setMemoryDisplayConfigurationType: NotificationType<Partial<MemoryDisplayConfiguration>> = { method: 'setMemoryDisplayConfiguration' };
+export const resetMemoryDisplayConfigurationType: NotificationType<void> = { method: 'resetMemoryDisplayConfiguration' };
 export const setOptionsType: RequestType<Partial<DebugProtocol.ReadMemoryArguments | undefined>, void> = { method: 'setOptions' };
 export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, MemoryReadResult> = { method: 'readMemory' };
 export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, MemoryWriteResult> = { method: 'writeMemory' };

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -14,28 +14,27 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as vscode from 'vscode';
 import type { DebugProtocol } from '@vscode/debugprotocol';
-import * as manifest from './manifest';
+import * as vscode from 'vscode';
 import { Messenger } from 'vscode-messenger';
-import { MessageParticipant, WebviewIdMessageParticipant } from 'vscode-messenger-common';
+import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
+import { VariableRange } from '../common/memory-range';
 import {
-    readyType,
-    logMessageType,
-    setOptionsType,
-    readMemoryType,
-    writeMemoryType,
     MemoryReadResult,
     MemoryWriteResult,
     getVariables,
-    memoryDisplayConfigurationChangedType,
-    columnVisibilityType,
+    logMessageType,
+    readMemoryType,
+    readyType,
+    resetMemoryDisplayConfigurationType,
     setMemoryDisplayConfigurationType,
+    setOptionsType,
+    writeMemoryType
 } from '../common/messaging';
-import { MemoryProvider } from './memory-provider';
+import { MemoryDisplayConfiguration, ScrollingBehavior } from '../webview/utils/view-types';
 import { outputChannelLogger } from './logger';
-import { VariableRange } from '../common/memory-range';
-import { ColumnVisibilityStatus, MemoryDisplayConfiguration as MemoryDisplayConfiguration, ScrollingBehavior } from '../webview/utils/view-types';
+import * as manifest from './manifest';
+import { MemoryProvider } from './memory-provider';
 
 interface Variable {
     name: string;
@@ -50,7 +49,7 @@ enum RefreshEnum {
 }
 
 const isMemoryVariable = (variable: Variable): variable is Variable => variable && !!(variable as Variable).memoryReference;
-const columnConfigurations = [
+const CONFIGURABLE_COLUMNS = [
     manifest.CONFIG_SHOW_ASCII_COLUMN,
     manifest.CONFIG_SHOW_VARIABLES_COLUMN,
 ];
@@ -135,8 +134,11 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         await this.getWebviewContent(panel);
 
         // Sets up an event listener to listen for messages passed from the webview view context
-        // and executes code based on the message that is recieved
-        this.setWebviewMessageListener(panel, initialMemory);
+        // and executes code based on the message that is received
+        const webviewParticipant = this.setWebviewMessageListener(panel, initialMemory);
+
+        // initialize with configuration
+        this.setInitialConfiguration(webviewParticipant);
     }
 
     protected getRefresh(): RefreshEnum {
@@ -174,7 +176,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         `;
     }
 
-    protected setWebviewMessageListener(panel: vscode.WebviewPanel, options?: Partial<DebugProtocol.ReadMemoryArguments>): void {
+    protected setWebviewMessageListener(panel: vscode.WebviewPanel, options?: Partial<DebugProtocol.ReadMemoryArguments>): WebviewIdMessageParticipant {
         const participant = this.messenger.registerWebviewPanel(panel);
 
         const disposables = [
@@ -188,78 +190,40 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
             this.messenger.onRequest(readMemoryType, request => this.readMemory(request), { sender: participant }),
             this.messenger.onRequest(writeMemoryType, request => this.writeMemory(request), { sender: participant }),
             this.messenger.onRequest(getVariables, request => this.getVariables(request), { sender: participant }),
-            this.messenger.onNotification(setMemoryDisplayConfigurationType, request => this.setConfiguration(request), { sender: participant }),
-            this.messenger.onNotification(columnVisibilityType, request => this.handleColumnToggled(request), { sender: participant }),
+            this.messenger.onNotification(resetMemoryDisplayConfigurationType, () => this.setInitialConfiguration(participant), { sender: participant }),
 
             this.memoryProvider.onDidStopDebug(() => {
                 if (this.refreshOnStop === RefreshEnum.on) {
                     this.refresh(participant);
                 }
             }),
-            this.onMemoryDisplayConfigurationChanged(participant),
-            this.onColumnVisibilityConfigurationChanged(participant),
         ];
         panel.onDidChangeViewState(newState => {
             if (newState.webviewPanel.visible) {
                 this.refresh(participant, options);
             }
         });
-        panel.onDidDispose(() => disposables.forEach(disposible => disposible.dispose()));
+        panel.onDidDispose(() => disposables.forEach(disposable => disposable.dispose()));
+
+        return participant;
     }
 
-    protected handleColumnToggled(request: ColumnVisibilityStatus): void {
-        const { id, active: visible } = request;
-        vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).update(`columns.${id}`, visible, vscode.ConfigurationTarget.Global);
-    }
-
-    protected setConfiguration(request: { id: string, value: unknown }): void {
-        const { id, value } = request;
-        vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).update(id, value, vscode.ConfigurationTarget.Global);
+    protected setInitialConfiguration(webviewParticipant: WebviewIdMessageParticipant): void {
+        this.messenger.sendNotification(setMemoryDisplayConfigurationType, webviewParticipant, this.getMemoryDisplayConfiguration());
     }
 
     protected async refresh(participant: WebviewIdMessageParticipant, options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
         this.messenger.sendRequest(setOptionsType, participant, options);
-        const memoryDisplayConfiguration = this.getMemoryDisplayConfiguration();
-        this.messenger.sendNotification(memoryDisplayConfigurationChangedType, participant, memoryDisplayConfiguration);
-        columnConfigurations.forEach(columnConfiguration => {
-            const [, id] = columnConfiguration.split('.');
-            const active = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(columnConfiguration) ?? true;
-            this.messenger.sendNotification(columnVisibilityType, participant, { id, active });
-        });
     }
 
     protected getMemoryDisplayConfiguration(): MemoryDisplayConfiguration {
         const memoryInspectorConfiguration = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME);
-        const wordsPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_WORDS_PER_GROUP) || manifest.DEFAULT_WORDS_PER_GROUP;
-        const groupsPerRow = memoryInspectorConfiguration.get<number>(manifest.CONFIG_GROUPS_PER_ROW) || manifest.DEFAULT_GROUPS_PER_ROW;
-        const scrollingBehavior = memoryInspectorConfiguration.get<ScrollingBehavior>(manifest.CONFIG_SCROLLING_BEHAVIOR) || manifest.DEFAULT_SCROLLING_BEHAVIOR;
-        return { wordsPerGroup, groupsPerRow, scrollingBehavior };
-    }
-
-    protected onMemoryDisplayConfigurationChanged(participant: MessageParticipant): vscode.Disposable {
-        const memoryDisplayConfigurations = [
-            manifest.CONFIG_WORDS_PER_GROUP,
-            manifest.CONFIG_GROUPS_PER_ROW,
-            manifest.CONFIG_SCROLLING_BEHAVIOR,
-        ];
-        return vscode.workspace.onDidChangeConfiguration(e => {
-            if (memoryDisplayConfigurations.some(configurationOption => e.affectsConfiguration(`${manifest.PACKAGE_NAME}.${configurationOption}`))) {
-                const configuration = this.getMemoryDisplayConfiguration();
-                this.messenger.sendNotification(memoryDisplayConfigurationChangedType, participant, configuration);
-            }
-        });
-    }
-
-    protected onColumnVisibilityConfigurationChanged(participant: MessageParticipant): vscode.Disposable {
-        return vscode.workspace.onDidChangeConfiguration(e => {
-            columnConfigurations.forEach(configuration => {
-                if (e.affectsConfiguration(`${manifest.PACKAGE_NAME}.${configuration}`)) {
-                    const [, id] = configuration.split('.');
-                    const active = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(configuration) ?? true;
-                    this.messenger.sendNotification(columnVisibilityType, participant, { id, active });
-                }
-            });
-        });
+        const wordsPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_WORDS_PER_GROUP, manifest.DEFAULT_WORDS_PER_GROUP);
+        const groupsPerRow = memoryInspectorConfiguration.get<number>(manifest.CONFIG_GROUPS_PER_ROW, manifest.DEFAULT_GROUPS_PER_ROW);
+        const scrollingBehavior = memoryInspectorConfiguration.get<ScrollingBehavior>(manifest.CONFIG_SCROLLING_BEHAVIOR, manifest.DEFAULT_SCROLLING_BEHAVIOR);
+        const visibleColumns = CONFIGURABLE_COLUMNS.filter(column => vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(column, true))
+            .map(columnId => columnId.replace('columns.', ''));
+        return { wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns };
     }
 
     protected async readMemory(request: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -16,14 +16,12 @@
 
 import { DebugProtocol } from '@vscode/debugprotocol';
 import React from 'react';
+import { ColumnStatus } from '../columns/column-contribution-service';
+import { Decoration, Endianness, Memory, MemoryDisplayConfiguration } from '../utils/view-types';
 import { MemoryTable } from './memory-table';
 import { OptionsWidget } from './options-widget';
-import { Decoration, Endianness, Memory, MemoryDisplayConfiguration } from '../utils/view-types';
-import { messenger } from '../view-messenger';
-import { memoryDisplayConfigurationChangedType } from '../../common/messaging';
-import { ColumnStatus } from '../columns/column-contribution-service';
 
-interface MemoryWidgetProps {
+interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     memory?: Memory;
     decorations: Decoration[];
     columns: ColumnStatus[];
@@ -33,31 +31,25 @@ interface MemoryWidgetProps {
     isMemoryFetching: boolean;
     refreshMemory: () => void;
     updateMemoryArguments: (memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>) => void;
-    toggleColumn(id: string, active: boolean): void;
+    updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
+    resetMemoryDisplayConfiguration: () => void;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
 }
 
-interface MemoryWidgetState extends MemoryDisplayConfiguration {
+interface MemoryWidgetState {
     endianness: Endianness;
     wordSize: number;
 }
 
 const defaultOptions: MemoryWidgetState = {
     endianness: Endianness.Little,
-    wordSize: 8,
-    wordsPerGroup: 1,
-    groupsPerRow: 4,
-    scrollingBehavior: 'Paginate',
+    wordSize: 8
 };
 
 export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidgetState> {
     constructor(props: MemoryWidgetProps) {
         super(props);
         this.state = { ...defaultOptions };
-    }
-
-    public componentDidMount(): void {
-        messenger.onNotification(memoryDisplayConfigurationChangedType, configuration => this.setState(configuration));
     }
 
     override render(): React.ReactNode {
@@ -69,29 +61,30 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 count={this.props.count}
                 endianness={this.state.endianness}
                 wordSize={this.state.wordSize}
-                wordsPerGroup={this.state.wordsPerGroup}
-                groupsPerRow={this.state.groupsPerRow}
+                wordsPerGroup={this.props.wordsPerGroup}
+                groupsPerRow={this.props.groupsPerRow}
                 updateMemoryArguments={this.props.updateMemoryArguments}
-                updateRenderOptions={this.updateRenderOptions}
+                updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
+                resetRenderOptions={this.props.resetMemoryDisplayConfiguration}
                 refreshMemory={this.props.refreshMemory}
-                toggleColumn={this.props.toggleColumn}
+                visibleColumns={this.props.visibleColumns}
             />
             <MemoryTable
                 decorations={this.props.decorations}
-                columnOptions={this.props.columns.filter(candidate => candidate.active)}
+                columnOptions={this.props.columns.filter(candidate => candidate.active || this.props.visibleColumns.includes(candidate.contribution.id))}
                 memory={this.props.memory}
                 endianness={this.state.endianness}
                 wordSize={this.state.wordSize}
-                wordsPerGroup={this.state.wordsPerGroup}
-                groupsPerRow={this.state.groupsPerRow}
+                wordsPerGroup={this.props.wordsPerGroup}
+                groupsPerRow={this.props.groupsPerRow}
                 offset={this.props.offset}
                 count={this.props.count}
                 fetchMemory={this.props.fetchMemory}
                 isMemoryFetching={this.props.isMemoryFetching}
-                scrollingBehavior={this.state.scrollingBehavior}
+                scrollingBehavior={this.props.scrollingBehavior}
+                visibleColumns={this.props.visibleColumns}
             />
         </div>);
     }
 
-    protected updateRenderOptions = (newState: Partial<MemoryWidgetState>) => this.setState(prevState => ({ ...prevState, ...newState }));
 }

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -22,10 +22,11 @@ import {
     logMessageType,
     setOptionsType,
     readMemoryType,
-    columnVisibilityType,
+    setMemoryDisplayConfigurationType,
+    resetMemoryDisplayConfigurationType,
 } from '../common/messaging';
 import type { DebugProtocol } from '@vscode/debugprotocol';
-import { ColumnVisibilityStatus, Decoration, Memory, MemoryState } from './utils/view-types';
+import { Decoration, Memory, MemoryDisplayConfiguration, MemoryState } from './utils/view-types';
 import { MemoryWidget } from './components/memory-widget';
 import { messenger } from './view-messenger';
 import { ColumnStatus, columnContributionService } from './columns/column-contribution-service';
@@ -37,13 +38,17 @@ import { DataColumn } from './columns/data-column';
 import { PrimeReactProvider } from 'primereact/api';
 import 'primeflex/primeflex.css';
 
-export interface MemoryAppState extends MemoryState {
+export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
     decorations: Decoration[];
     columns: ColumnStatus[];
 }
 
-export const DEFAULT_WORDS_PER_GROUP = 1;
-export const DEFAULT_GROUPS_PER_ROW = 4;
+const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
+    wordsPerGroup: 1,
+    groupsPerRow: 4,
+    scrollingBehavior: 'Paginate',
+    visibleColumns: ['ascii', 'variables']
+};
 
 class App extends React.Component<{}, MemoryAppState> {
 
@@ -61,14 +66,15 @@ class App extends React.Component<{}, MemoryAppState> {
             count: 256,
             decorations: [],
             columns: columnContributionService.getColumns(),
-            isMemoryFetching: false
+            isMemoryFetching: false,
+            ...MEMORY_DISPLAY_CONFIGURATION_DEFAULTS
         };
     }
 
     public componentDidMount(): void {
         messenger.onRequest(setOptionsType, options => this.setOptions(options));
+        messenger.onNotification(setMemoryDisplayConfigurationType, config => this.setState(prevState => ({ ...prevState, ...config })));
         messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
-        messenger.onNotification(columnVisibilityType, request => this.handleColumnVisibilityChanged(request));
     }
 
     public render(): React.ReactNode {
@@ -81,21 +87,22 @@ class App extends React.Component<{}, MemoryAppState> {
                 offset={this.state.offset ?? 0}
                 count={this.state.count}
                 updateMemoryArguments={this.updateMemoryState}
+                updateMemoryDisplayConfiguration={this.updateMemoryDisplayConfiguration}
+                resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
                 refreshMemory={this.refreshMemory}
-                toggleColumn={this.toggleColumn}
                 fetchMemory={this.fetchMemory}
                 isMemoryFetching={this.state.isMemoryFetching}
+                groupsPerRow={this.state.groupsPerRow}
+                wordsPerGroup={this.state.wordsPerGroup}
+                scrollingBehavior={this.state.scrollingBehavior}
+                visibleColumns={this.state.visibleColumns}
             />
         </PrimeReactProvider>;
     }
 
-    protected async handleColumnVisibilityChanged(request: ColumnVisibilityStatus): Promise<void> {
-        const { active, id } = request;
-        const columns = active ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
-        this.setState({ columns });
-    }
-
     protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryDisplayConfigurationType, HOST_EXTENSION, undefined);
 
     protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
         messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);
@@ -144,11 +151,6 @@ class App extends React.Component<{}, MemoryAppState> {
         return { bytes, address };
     }
 
-    protected toggleColumn = (id: string, active: boolean): void => { this.doToggleColumn(id, active); };
-
-    protected doToggleColumn(id: string, active: boolean): void {
-        messenger.sendNotification(columnVisibilityType, HOST_EXTENSION, { id, active });
-    }
 }
 
 const container = document.getElementById('root') as Element;

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import type { DebugProtocol } from '@vscode/debugprotocol';
+import deepequal from 'fast-deep-equal';
 import type * as React from 'react';
 import { areRangesEqual, BigIntMemoryRange } from '../../common/memory-range';
-import deepequal from 'fast-deep-equal';
 
 export enum Endianness {
     Little = 'Little Endian',
@@ -77,16 +77,7 @@ export interface MemoryDisplayConfiguration {
     wordsPerGroup: number;
     groupsPerRow: number;
     scrollingBehavior: ScrollingBehavior;
-}
-
-export interface ColumnVisibilityStatus {
-    id: string;
-    active: boolean;
-}
-
-export interface MemoryDisplayConfigurationChangeRequest {
-    id: 'groupings.wordsPerGroup' | 'groupings.groupsPerRow' | 'scrollingBehavior';
-    value: number;
+    visibleColumns: string[];
 }
 
 export type ReactInteraction<E extends Element = Element> = React.MouseEvent<E> | React.KeyboardEvent<E>;


### PR DESCRIPTION
# DO NOT MERGE THIS IS JUST FOR INTERNAL REVIEW

#### What it does

Implements the following behavior for memory display options:

* A new memory view is opened with the display configuration as defined in the VS Code settings.
* Changes made to the local options in a view affect only the specific view where the changes were made.
* Altering global settings in the VS Code prefs doesn't impact any already open views.
* Add button in the local options to reset to defaults, which applies the configuration as defined in the VS Code settings.

Implementation-wise this applies the following changes:

* Defaults from VS Code setting are initially set from main.
* From then on, memory display configuration lives in the view state only.
* Remove previous messenger-based handling to change configuration.
* Consolidate column activation and other display configurations into one type.
* Add reset button to options which sends a notification to main so that it re-sets the options defined in the VS Code settings.

#### How to test
* [ ] Open VS Code settings for Memory inspector
* [ ] Start a debug session
* [ ] Open Memory Inspector view instance 1 and verify it applies the ones configured in the VS Code settings
* [ ] Open Memory Inspector view instance 2 and verify it applies the ones configured in the VS Code settings
* [ ] Change all memory display options in instance 1 (column activations, words by group, groups per row) and verify
  * [ ] They have the expected effect in instance 1
  * [ ] They have no effect in instance 2
  * [ ] They have no effect on the settings
* [ ] Change memory display options in instance 2 and check again they don't have an effect outside of this view
* [ ] Click button *Reset to Defaults* in the memory display options of instance 2 and verify
  * [ ] They reset exactly to the defaults from the VS Code settings
  * [ ] The instance 1 remains unchanged
* [ ] Change the defaults in the VS Code settings
* [ ] Click button *Reset to Defaults* in the memory display options of instance 2 again and verify they are applied correctly

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
