### PR TITLE
Allow to configure word size and add group separator

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -75,3 +75,7 @@
 .more-memory-select select:hover {
   background: var(--vscode-dropdown-background);
 }
+
+.radix-prefix {
+  opacity: .6;
+}

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -76,6 +76,6 @@
   background: var(--vscode-dropdown-background);
 }
 
-.byte-group {
+.byte-group:not(:last-of-type) {
   margin-right: 0.2em;
 }

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -30,7 +30,7 @@
 /* == MoreMemorySelect == */
 
 .bytes-select {
-  color: var(--vscode-dropdown-forground);
+  color: var(--vscode-dropdown-foreground);
   border-radius: 2px;
   font-size: var(--vscode-font-size);
   border: 1px solid var(--vscode-dropdown-border);
@@ -74,4 +74,8 @@
 
 .more-memory-select select:hover {
   background: var(--vscode-dropdown-background);
+}
+
+.byte-group {
+  margin-right: 0.2em;
 }

--- a/media/multi-select.css
+++ b/media/multi-select.css
@@ -19,5 +19,5 @@
 }
 
 .multi-select-label {
-  font-weight: bold;
+  font-size: small;
 }

--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -81,6 +81,11 @@
   align-self: start;
 }
 
+.advanced-options-content h2 {
+  font-size: 120%;
+  margin: 0.5rem 0 0 0;
+}
+
 .advanced-options-toggle {
   margin-left: auto;
   align-self: start;
@@ -88,7 +93,7 @@
 }
 
 .advanced-options-content {
-  width: 160px;
+  width: 180px;
   text-align: left;
   display: flex;
   flex-direction: column;

--- a/media/options-widget.css
+++ b/media/options-widget.css
@@ -14,6 +14,39 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+.memory-options-widget {
+  margin-bottom: 8px;
+  padding-bottom: 4px;
+}
+
+.memory-options-widget .title-container {
+  display: flex;
+  align-items: center;
+}
+
+.memory-options-widget .title-container h1 {
+  flex-grow: 1;
+  font-size: 1.3em;
+  margin: 8px 0 4px;
+}
+
+.memory-options-widget .title-container input {
+  margin: 5px 0 0;
+  flex-grow: 1;
+}
+
+.memory-options-widget .edit-label-toggle {
+  position: absolute;
+  right: 24px;
+  top: 8px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.memory-options-widget .title-container:hover .edit-label-toggle {
+  opacity: 1;
+}
+
 .core-options {
   display: flex;
   flex-direction: row;
@@ -21,6 +54,7 @@
   margin: 6px 0;
   flex-wrap: wrap;
   border-bottom: 1px solid var(--vscode-widget-border);
+  border-top: 1px solid var(--vscode-widget-border);
 }
 
 .form-options {

--- a/package.json
+++ b/package.json
@@ -206,6 +206,28 @@
             "Appends new memory to bounds of current request, resulting in a growing list."
           ],
           "description": "Behavior when adding more memory beyond the current view."
+        },
+        "memory-inspector.addressRadix": {
+          "type": "number",
+          "enum": [
+            2,
+            8,
+            10,
+            16
+          ],
+          "default": 16,
+          "enumDescriptions": [
+            "Binary format (base 2)",
+            "Octal format (base 8)",
+            "Decimal format (base 10)",
+            "Hexadecimal format (base 16)"
+          ],
+          "description": "Specifies the numerical base (radix) for displaying memory addresses."
+        },
+        "memory-inspector.showRadixPrefix": {
+          "type": "boolean",
+          "default": true,
+          "description": "Display the radix prefix (e.g., '0x' for hexadecimal, '0b' for binary) before memory addresses."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -159,6 +159,18 @@
           "default": "on",
           "description": "Refresh memory views when debugger stops"
         },
+        "memory-inspector.groupings.bytesPerWord": {
+          "type": "number",
+          "enum": [
+            1,
+            2,
+            4,
+            8,
+            16
+          ],
+          "default": 1,
+          "description": "Default bytes per word"
+        },
         "memory-inspector.groupings.wordsPerGroup": {
           "type": "number",
           "enum": [

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -65,8 +65,33 @@ export function determineRelationship(candidate: bigint, range?: BigIntMemoryRan
     return RangeRelationship.Within;
 }
 
+export enum Radix {
+    Binary = 2,
+    Octal = 8,
+    Decimal = 10,
+    Hexadecimal = 16,
+}
+
+export type Architecture = 32 | 64;
+
+const radixPrefixMap: { [key: number]: string } = {
+    [Radix.Binary]: '0b',
+    [Radix.Octal]: '0o',
+    [Radix.Decimal]: '0d',
+    [Radix.Hexadecimal]: '0x',
+};
+
+export function getRadixMarker(radix: Radix): string {
+    return radixPrefixMap[radix];
+}
+
+export function getAddressString(address: bigint, radix: Radix, architecture: Architecture = 32, addPadding = false): string {
+    const paddedLength = addPadding ? Math.ceil(architecture / Math.log2(radix)) : 0;
+    return address.toString(radix).padStart(paddedLength, '0');
+}
+
 export function toHexStringWithRadixMarker(target: bigint): string {
-    return `0x${target.toString(16)}`;
+    return `${getRadixMarker(Radix.Hexadecimal)}${getAddressString(target, Radix.Hexadecimal)}`;
 }
 
 export interface VariableMetadata {

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -26,6 +26,7 @@ export const readyType: NotificationType<void> = { method: 'ready' };
 export const logMessageType: RequestType<string, void> = { method: 'logMessage' };
 export const setMemoryViewSettingsType: NotificationType<Partial<MemoryViewSettings>> = { method: 'setMemoryViewSettings' };
 export const resetMemoryViewSettingsType: NotificationType<void> = { method: 'resetMemoryViewSettings' };
+export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const setOptionsType: RequestType<Partial<DebugProtocol.ReadMemoryArguments | undefined>, void> = { method: 'setOptions' };
 export const readMemoryType: RequestType<DebugProtocol.ReadMemoryArguments, MemoryReadResult> = { method: 'readMemory' };
 export const writeMemoryType: RequestType<DebugProtocol.WriteMemoryArguments, MemoryWriteResult> = { method: 'writeMemory' };

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -21,7 +21,7 @@ export const EDITOR_NAME = `${PACKAGE_NAME}.inspect`;
 export const CONFIG_LOGGING_VERBOSITY = 'loggingVerbosity';
 export const DEFAULT_LOGGING_VERBOSITY = 'warn';
 export const CONFIG_DEBUG_TYPES = 'debugTypes';
-export const DEFAULT_DEBUG_TYPES = [ 'gdb', 'embedded-debug', 'arm-debugger' ];
+export const DEFAULT_DEBUG_TYPES = ['gdb', 'embedded-debug', 'arm-debugger'];
 export const CONFIG_REFRESH_ON_STOP = 'refreshOnStop';
 export const DEFAULT_REFRESH_ON_STOP = 'on';
 
@@ -31,6 +31,10 @@ export const CONFIG_GROUPS_PER_ROW = 'groupings.groupsPerRow';
 export const DEFAULT_GROUPS_PER_ROW = 4;
 export const CONFIG_SCROLLING_BEHAVIOR = 'scrollingBehavior';
 export const DEFAULT_SCROLLING_BEHAVIOR = 'Paginate';
+export const CONFIG_ADDRESS_RADIX = 'addressRadix';
+export const DEFAULT_ADDRESS_RADIX = 16;
+export const CONFIG_SHOW_RADIX_PREFIX = 'showRadixPrefix';
+export const DEFAULT_SHOW_RADIX_PREFIX = true;
 
 export const CONFIG_SHOW_VARIABLES_COLUMN = 'columns.variables';
 export const CONFIG_SHOW_ASCII_COLUMN = 'columns.ascii';

--- a/src/plugin/manifest.ts
+++ b/src/plugin/manifest.ts
@@ -25,6 +25,8 @@ export const DEFAULT_DEBUG_TYPES = [ 'gdb', 'embedded-debug', 'arm-debugger' ];
 export const CONFIG_REFRESH_ON_STOP = 'refreshOnStop';
 export const DEFAULT_REFRESH_ON_STOP = 'on';
 
+export const CONFIG_BYTES_PER_WORD = 'groupings.bytesPerWord';
+export const DEFAULT_BYTES_PER_WORD = 1;
 export const CONFIG_WORDS_PER_GROUP = 'groupings.wordsPerGroup';
 export const DEFAULT_WORDS_PER_GROUP = 1;
 export const CONFIG_GROUPS_PER_ROW = 'groupings.groupsPerRow';

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -224,7 +224,9 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         const visibleColumns = CONFIGURABLE_COLUMNS
             .filter(column => vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(column, false))
             .map(columnId => columnId.replace('columns.', ''));
-        return { title, wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns };
+        const addressRadix = memoryInspectorConfiguration.get<number>(manifest.CONFIG_ADDRESS_RADIX, manifest.DEFAULT_ADDRESS_RADIX);
+        const showRadixPrefix = memoryInspectorConfiguration.get<boolean>(manifest.CONFIG_SHOW_RADIX_PREFIX, manifest.DEFAULT_SHOW_RADIX_PREFIX);
+        return { title, wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns, addressRadix, showRadixPrefix };
     }
 
     protected async readMemory(request: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -30,6 +30,7 @@ import {
     getVariables,
     setMemoryViewSettingsType,
     resetMemoryViewSettingsType,
+    setTitleType,
 } from '../common/messaging';
 import { MemoryProvider } from './memory-provider';
 import { outputChannelLogger } from './logger';
@@ -61,6 +62,8 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
 
     protected messenger: Messenger;
     protected refreshOnStop: RefreshEnum;
+
+    protected panelIndices: number = 1;
 
     public constructor(protected extensionUri: vscode.Uri, protected memoryProvider: MemoryProvider) {
         this.messenger = new Messenger();
@@ -125,7 +128,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         };
 
         if (!panel) {
-            panel = vscode.window.createWebviewPanel(MemoryWebview.ViewType, 'Memory Inspector', vscode.ViewColumn.Active, options);
+            panel = vscode.window.createWebviewPanel(MemoryWebview.ViewType, `Memory ${this.panelIndices++}`, vscode.ViewColumn.Active, options);
         } else {
             panel.webview.options = options;
         }
@@ -135,10 +138,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
 
         // Sets up an event listener to listen for messages passed from the webview view context
         // and executes code based on the message that is received
-        const webviewParticipant = this.setWebviewMessageListener(panel, initialMemory);
-
-        // initialize with configuration
-        this.setInitialSettings(webviewParticipant);
+        this.setWebviewMessageListener(panel, initialMemory);
     }
 
     protected getRefresh(): RefreshEnum {
@@ -176,11 +176,12 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         `;
     }
 
-    protected setWebviewMessageListener(panel: vscode.WebviewPanel, options?: Partial<DebugProtocol.ReadMemoryArguments>): WebviewIdMessageParticipant {
+    protected setWebviewMessageListener(panel: vscode.WebviewPanel, options?: Partial<DebugProtocol.ReadMemoryArguments>): void {
         const participant = this.messenger.registerWebviewPanel(panel);
 
         const disposables = [
             this.messenger.onNotification(readyType, () => {
+                this.setInitialSettings(participant, panel.title);
                 this.refresh(participant, options);
             }, { sender: participant }),
             this.messenger.onRequest(setOptionsType, o => {
@@ -190,7 +191,8 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
             this.messenger.onRequest(readMemoryType, request => this.readMemory(request), { sender: participant }),
             this.messenger.onRequest(writeMemoryType, request => this.writeMemory(request), { sender: participant }),
             this.messenger.onRequest(getVariables, request => this.getVariables(request), { sender: participant }),
-            this.messenger.onNotification(resetMemoryViewSettingsType, () => this.setInitialSettings(participant), { sender: participant }),
+            this.messenger.onNotification(resetMemoryViewSettingsType, () => this.setInitialSettings(participant, panel.title), { sender: participant }),
+            this.messenger.onNotification(setTitleType, title => { panel.title = title; }, { sender: participant }),
 
             this.memoryProvider.onDidStopDebug(() => {
                 if (this.refreshOnStop === RefreshEnum.on) {
@@ -204,19 +206,17 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
             }
         });
         panel.onDidDispose(() => disposables.forEach(disposable => disposable.dispose()));
-
-        return participant;
-    }
-
-    protected setInitialSettings(webviewParticipant: WebviewIdMessageParticipant): void {
-        this.messenger.sendNotification(setMemoryViewSettingsType, webviewParticipant, this.getMemoryViewSettings());
     }
 
     protected async refresh(participant: WebviewIdMessageParticipant, options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
         this.messenger.sendRequest(setOptionsType, participant, options);
     }
 
-    protected getMemoryViewSettings(): MemoryViewSettings {
+    protected setInitialSettings(webviewParticipant: WebviewIdMessageParticipant, title: string): void {
+        this.messenger.sendNotification(setMemoryViewSettingsType, webviewParticipant, this.getMemoryViewSettings(title));
+    }
+
+    protected getMemoryViewSettings(title: string): MemoryViewSettings {
         const memoryInspectorConfiguration = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME);
         const wordsPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_WORDS_PER_GROUP, manifest.DEFAULT_WORDS_PER_GROUP);
         const groupsPerRow = memoryInspectorConfiguration.get<number>(manifest.CONFIG_GROUPS_PER_ROW, manifest.DEFAULT_GROUPS_PER_ROW);
@@ -224,7 +224,7 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
         const visibleColumns = CONFIGURABLE_COLUMNS
             .filter(column => vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(column, false))
             .map(columnId => columnId.replace('columns.', ''));
-        return { wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns };
+        return { title, wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns };
     }
 
     protected async readMemory(request: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -218,13 +218,14 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
 
     protected getMemoryViewSettings(): MemoryViewSettings {
         const memoryInspectorConfiguration = vscode.workspace.getConfiguration(manifest.PACKAGE_NAME);
+        const bytesPerWord = memoryInspectorConfiguration.get<number>(manifest.CONFIG_BYTES_PER_WORD, manifest.DEFAULT_BYTES_PER_WORD);
         const wordsPerGroup = memoryInspectorConfiguration.get<number>(manifest.CONFIG_WORDS_PER_GROUP, manifest.DEFAULT_WORDS_PER_GROUP);
         const groupsPerRow = memoryInspectorConfiguration.get<number>(manifest.CONFIG_GROUPS_PER_ROW, manifest.DEFAULT_GROUPS_PER_ROW);
         const scrollingBehavior = memoryInspectorConfiguration.get<ScrollingBehavior>(manifest.CONFIG_SCROLLING_BEHAVIOR, manifest.DEFAULT_SCROLLING_BEHAVIOR);
         const visibleColumns = CONFIGURABLE_COLUMNS
             .filter(column => vscode.workspace.getConfiguration(manifest.PACKAGE_NAME).get<boolean>(column, false))
             .map(columnId => columnId.replace('columns.', ''));
-        return { wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns };
+        return { bytesPerWord, wordsPerGroup, groupsPerRow, scrollingBehavior, visibleColumns };
     }
 
     protected async readMemory(request: DebugProtocol.ReadMemoryArguments): Promise<MemoryReadResult> {

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -14,9 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ReactNode } from 'react';
-import { BigIntMemoryRange, toHexStringWithRadixMarker } from '../../common/memory-range';
+import React, { ReactNode } from 'react';
+import { BigIntMemoryRange, getAddressString, getRadixMarker } from '../../common/memory-range';
 import { ColumnContribution } from './column-contribution-service';
+import { Memory, MemoryDisplayConfiguration } from '../utils/view-types';
 
 export class AddressColumn implements ColumnContribution {
     static ID = 'address';
@@ -25,7 +26,10 @@ export class AddressColumn implements ColumnContribution {
     readonly label = 'Address';
     readonly priority = 0;
 
-    render(range: BigIntMemoryRange): ReactNode {
-        return toHexStringWithRadixMarker(range.startAddress);
+    render(range: BigIntMemoryRange, _: Memory, options: MemoryDisplayConfiguration): ReactNode {
+        return <span className='memory-start-address'>
+            {options.showRadixPrefix && <span className='radix-prefix'>{getRadixMarker(options.addressRadix)}</span>}
+            <span className='address'>{getAddressString(range.startAddress, options.addressRadix)}</span>
+        </span>;
     }
 }

--- a/src/webview/columns/ascii-column.ts
+++ b/src/webview/columns/ascii-column.ts
@@ -33,8 +33,9 @@ export class AsciiColumn implements ColumnContribution {
     readonly label = 'ASCII';
     readonly priority = 3;
     render(range: BigIntMemoryRange, memory: Memory, options: TableRenderOptions): ReactNode {
-        const startOffset = toOffset(memory.address, range.startAddress, options.wordSize);
-        const endOffset = toOffset(memory.address, range.endAddress, options.wordSize);
+        const wordSize = options.bytesPerWord * 8;
+        const startOffset = toOffset(memory.address, range.startAddress, wordSize);
+        const endOffset = toOffset(memory.address, range.endAddress, wordSize);
         let result = '';
         for (let i = startOffset; i < endOffset; i++) {
             result += getASCIIForSingleByte(memory.bytes[i]);

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -44,9 +44,8 @@ export class DataColumn implements ColumnContribution {
     }
 
     protected renderWord(memory: Memory, options: TableRenderOptions, currentAddress: bigint): React.ReactNode {
-        const itemsPerByte = options.wordSize / 8;
-        const initialOffset = toOffset(memory.address, currentAddress, options.wordSize);
-        const finalOffset = initialOffset + itemsPerByte;
+        const initialOffset = toOffset(memory.address, currentAddress, options.bytesPerWord * 8);
+        const finalOffset = initialOffset + options.bytesPerWord;
         const bytes = [];
         for (let i = initialOffset; i < finalOffset; i++) {
             bytes.push(this.renderEightBits(memory, currentAddress, i));

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -118,12 +118,12 @@ interface MemoryTableState {
     selection: DataTableCellSelection<MemoryRowData[]> | null;
 }
 
-type MemorySizeOptions = Pick<MemoryTableProps, 'wordSize' | 'wordsPerGroup' | 'groupsPerRow'>;
+type MemorySizeOptions = Pick<MemoryTableProps, 'bytesPerWord' | 'wordsPerGroup' | 'groupsPerRow'>;
 namespace MemorySizeOptions {
     export function create(props: MemoryTableProps): MemorySizeOptions {
-        const { groupsPerRow, wordSize, wordsPerGroup }: MemorySizeOptions = props;
+        const { groupsPerRow, bytesPerWord, wordsPerGroup }: MemorySizeOptions = props;
         return {
-            wordSize,
+            bytesPerWord,
             groupsPerRow,
             wordsPerGroup
         };
@@ -312,7 +312,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
 
     protected createMemoryRowListOptions(memory: Memory, options: MemorySizeOptions): MemoryRowListOptions {
         const wordsPerRow = options.wordsPerGroup * options.groupsPerRow;
-        const numRows = Math.ceil((memory.bytes.length * 8) / (wordsPerRow * options.wordSize));
+        const numRows = Math.ceil((memory.bytes.length * 8) / (wordsPerRow * options.bytesPerWord * 8));
         const bigWordsPerRow = BigInt(wordsPerRow);
 
         return {

--- a/src/webview/components/memory-table.tsx
+++ b/src/webview/components/memory-table.tsx
@@ -312,7 +312,7 @@ export class MemoryTable extends React.PureComponent<MemoryTableProps, MemoryTab
 
     protected createMemoryRowListOptions(memory: Memory, options: MemorySizeOptions): MemoryRowListOptions {
         const wordsPerRow = options.wordsPerGroup * options.groupsPerRow;
-        const numRows = Math.ceil((memory.bytes.length * 8) / (wordsPerRow * options.bytesPerWord * 8));
+        const numRows = Math.ceil((memory.bytes.length) / (wordsPerRow * options.bytesPerWord));
         const bigWordsPerRow = BigInt(wordsPerRow);
 
         return {

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -39,12 +39,10 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
 
 interface MemoryWidgetState {
     endianness: Endianness;
-    wordSize: number;
 }
 
 const defaultOptions: MemoryWidgetState = {
     endianness: Endianness.Little,
-    wordSize: 8
 };
 
 export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidgetState> {
@@ -61,7 +59,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 offset={this.props.offset}
                 count={this.props.count}
                 endianness={this.state.endianness}
-                wordSize={this.state.wordSize}
+                bytesPerWord={this.props.bytesPerWord}
                 wordsPerGroup={this.props.wordsPerGroup}
                 groupsPerRow={this.props.groupsPerRow}
                 updateMemoryArguments={this.props.updateMemoryArguments}
@@ -75,7 +73,7 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 columnOptions={this.props.columns.filter(candidate => candidate.active)}
                 memory={this.props.memory}
                 endianness={this.state.endianness}
-                wordSize={this.state.wordSize}
+                bytesPerWord={this.props.bytesPerWord}
                 wordsPerGroup={this.props.wordsPerGroup}
                 groupsPerRow={this.props.groupsPerRow}
                 offset={this.props.offset}

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -72,6 +72,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 updateRenderOptions={this.props.updateMemoryDisplayConfiguration}
                 resetRenderOptions={this.props.resetMemoryDisplayConfiguration}
                 refreshMemory={this.props.refreshMemory}
+                addressRadix={this.props.addressRadix}
+                showRadixPrefix={this.props.showRadixPrefix}
                 toggleColumn={this.props.toggleColumn}
             />
             <MemoryTable
@@ -87,6 +89,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
                 fetchMemory={this.props.fetchMemory}
                 isMemoryFetching={this.props.isMemoryFetching}
                 scrollingBehavior={this.props.scrollingBehavior}
+                addressRadix={this.props.addressRadix}
+                showRadixPrefix={this.props.showRadixPrefix}
             />
         </div>);
     }

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -23,6 +23,7 @@ import { OptionsWidget } from './options-widget';
 
 interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     memory?: Memory;
+    title: string;
     decorations: Decoration[];
     columns: ColumnStatus[];
     memoryReference: string;
@@ -34,6 +35,7 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     toggleColumn(id: string, active: boolean): void;
     updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
     resetMemoryDisplayConfiguration: () => void;
+    updateTitle: (title: string) => void;
     fetchMemory(partialOptions?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void>
 }
 
@@ -56,6 +58,8 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
     override render(): React.ReactNode {
         return (<div className='flex flex-column h-full'>
             <OptionsWidget
+                title={this.props.title}
+                updateTitle={this.props.updateTitle}
                 columnOptions={this.props.columns}
                 memoryReference={this.props.memoryReference}
                 offset={this.props.offset}

--- a/src/webview/components/multi-select.tsx
+++ b/src/webview/components/multi-select.tsx
@@ -57,7 +57,7 @@ const MultiSelectBar: React.FC<MultiSelectProps> = ({ items, onSelectionChanged,
 
 export const MultiSelectWithLabel: React.FC<MultiSelectProps> = ({ id, label, items, onSelectionChanged }) => (
     <div className='flex flex-column'>
-        <label className='multi-select-label mb-2'>{label}</label>
+        <h2 className='multi-select-label mb-2 mt-0'>{label}</h2>
         <MultiSelectBar id={id} items={items} onSelectionChanged={onSelectionChanged} label={label} />
     </div>
 );

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -27,6 +27,7 @@ import {
     SerializedTableRenderOptions,
 } from '../utils/view-types';
 import { MultiSelectWithLabel } from './multi-select';
+import { Checkbox } from 'primereact/checkbox';
 
 export interface OptionsWidgetProps
     extends Omit<TableRenderOptions, 'scrollingBehavior'>,
@@ -52,6 +53,8 @@ const enum InputId {
     Length = 'length',
     WordsPerGroup = 'words-per-group',
     GroupsPerRow = 'groups-per-row',
+    AddressRadix = 'address-radix',
+    ShowRadixPrefix = 'show-radix-prefix',
 }
 
 interface OptionsForm {
@@ -260,6 +263,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                     onSelectionChanged={this.handleColumnActivationChange}
                                 />
                             )}
+                            <h2>Memory Format</h2>
                             <label
                                 htmlFor={InputId.WordsPerGroup}
                                 className='advanced-options-label mt-1'
@@ -283,7 +287,35 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                                 value={this.props.groupsPerRow}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
                                 options={allowedGroupsPerRow}
+                                className='advanced-options-dropdown' />
+
+                            <h2>Address Format</h2>
+                            <label
+                                htmlFor={InputId.AddressRadix}
+                                className='advanced-options-label'
+                            >
+                                Format (Radix)
+                            </label>
+                            <Dropdown
+                                id={InputId.AddressRadix}
+                                value={Number(this.props.addressRadix)}
+                                onChange={this.handleAdvancedOptionsDropdownChange}
+                                options={[
+                                    { label: '2 - Binary', value: 2 },
+                                    { label: '8 - Octal', value: 8 },
+                                    { label: '10 - Decimal', value: 10 },
+                                    { label: '16 - Hexadecimal', value: 16 }
+                                ]}
                                 className="advanced-options-dropdown" />
+
+                            <div className='flex align-items-center'>
+                                <Checkbox
+                                    id={InputId.ShowRadixPrefix}
+                                    onChange={this.handleAdvancedOptionsDropdownChange}
+                                    checked={!!this.props.showRadixPrefix}
+                                />
+                                <label htmlFor={InputId.ShowRadixPrefix} className='ml-2'>Display Radix Prefix</label>
+                            </div>
                         </div>
                     </OverlayPanel>
                 </div>
@@ -349,6 +381,12 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWi
                 break;
             case InputId.GroupsPerRow:
                 this.props.updateRenderOptions({ groupsPerRow: Number(value) });
+                break;
+            case InputId.AddressRadix:
+                this.props.updateRenderOptions({ addressRadix: Number(value) });
+                break;
+            case InputId.ShowRadixPrefix:
+                this.props.updateRenderOptions({ showRadixPrefix: !!event.target.checked });
                 break;
             default: {
                 throw new Error(`${id} can not be handled. Did you call the correct method?`);

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -21,7 +21,7 @@ import { Dropdown, DropdownChangeEvent } from 'primereact/dropdown';
 import { InputText } from 'primereact/inputtext';
 import { OverlayPanel } from 'primereact/overlaypanel';
 import { classNames } from 'primereact/utils';
-import React, { KeyboardEvent, MouseEventHandler } from 'react';
+import React, { FocusEventHandler, KeyboardEvent, KeyboardEventHandler, MouseEventHandler } from 'react';
 import { TableRenderOptions } from '../columns/column-contribution-service';
 import {
     SerializedTableRenderOptions,
@@ -31,13 +31,19 @@ import { MultiSelectWithLabel } from './multi-select';
 export interface OptionsWidgetProps
     extends Omit<TableRenderOptions, 'scrollingBehavior'>,
     Required<DebugProtocol.ReadMemoryArguments> {
+    title: string;
     updateRenderOptions: (options: Partial<SerializedTableRenderOptions>) => void;
     resetRenderOptions: () => void;
+    updateTitle: (title: string) => void;
     updateMemoryArguments: (
         memoryArguments: Partial<DebugProtocol.ReadMemoryArguments>
     ) => void;
     refreshMemory: () => void;
     toggleColumn(id: string, isVisible: boolean): void;
+}
+
+interface OptionsWidgetState {
+    isTitleEditing: boolean;
 }
 
 const enum InputId {
@@ -57,9 +63,10 @@ interface OptionsForm {
 const allowedBytesPerGroup = [1, 2, 4, 8, 16];
 const allowedGroupsPerRow = [1, 2, 4, 8, 16, 32];
 
-export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
+export class OptionsWidget extends React.Component<OptionsWidgetProps, OptionsWidgetState> {
     protected formConfig: FormikConfig<OptionsForm>;
     protected extendedOptions = React.createRef<OverlayPanel>();
+    protected labelEditInput = React.createRef<HTMLInputElement>();
 
     protected get optionsFormValues(): OptionsForm {
         return {
@@ -80,6 +87,7 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
                 this.props.refreshMemory();
             },
         };
+        this.state = { isTitleEditing: false };
     }
 
     protected validate = (values: OptionsForm) => {
@@ -117,11 +125,43 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
         return errors;
     };
 
+    componentDidUpdate(_: Readonly<OptionsWidgetProps>, prevState: Readonly<OptionsWidgetState>): void {
+        if (!prevState.isTitleEditing && this.state.isTitleEditing) {
+            this.labelEditInput.current?.focus();
+            this.labelEditInput.current?.select();
+        }
+    }
+
     override render(): React.ReactNode {
         this.formConfig.initialValues = this.optionsFormValues;
+        const isLabelEditing = this.state.isTitleEditing;
 
         return (
             <div className='memory-options-widget px-4'>
+                <div className='title-container'>
+                    <InputText
+                        ref={this.labelEditInput}
+                        type='text'
+                        onKeyDown={this.handleTitleEditingKeyDown}
+                        onBlur={this.confirmEditedTitle}
+                        style={{ display: isLabelEditing ? 'block' : 'none' }}
+                    />
+                    {!isLabelEditing && (
+                        <h1 onDoubleClick={this.enableTitleEditing}>{this.props.title}</h1>
+                    )}
+                    {!isLabelEditing && (
+                        <Button
+                            type='button'
+                            className='edit-label-toggle'
+                            icon='codicon codicon-edit'
+                            onClick={this.enableTitleEditing}
+                            title='Edit view title'
+                            aria-label='Edit view title'
+                            rounded
+                            aria-haspopup
+                        />
+                    )}
+                </div>
                 <div className='core-options py-2'>
                     <Formik {...this.formConfig}>
                         {formik => (
@@ -326,5 +366,35 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
     }
 
     protected handleResetAdvancedOptions: MouseEventHandler<HTMLButtonElement> | undefined = () => this.props.resetRenderOptions();
+
+    protected enableTitleEditing = () => this.doEnableTitleEditing();
+    protected doEnableTitleEditing(): void {
+        if (this.labelEditInput.current) {
+            this.labelEditInput.current.value = this.props.title;
+        }
+        this.setState({ isTitleEditing: true });
+    }
+
+    protected disableTitleEditing = () => this.doDisableTitleEditing();
+    protected doDisableTitleEditing(): void {
+        this.setState({ isTitleEditing: false });
+    }
+
+    protected handleTitleEditingKeyDown: KeyboardEventHandler<HTMLInputElement> | undefined = event => this.doHandleTitleEditingKeyDown(event);
+    protected doHandleTitleEditingKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
+        if (event.key === 'Enter' && this.labelEditInput.current) {
+            this.doConfirmEditedTitle();
+        } else if (event.key === 'Escape') {
+            this.disableTitleEditing();
+        }
+    }
+
+    protected confirmEditedTitle: FocusEventHandler<HTMLInputElement> | undefined = () => this.doConfirmEditedTitle();
+    protected doConfirmEditedTitle(): void {
+        if (this.state.isTitleEditing && this.labelEditInput.current) {
+            this.props.updateTitle(this.labelEditInput.current.value.trim());
+            this.disableTitleEditing();
+        }
+    }
 
 }

--- a/src/webview/components/options-widget.tsx
+++ b/src/webview/components/options-widget.tsx
@@ -44,6 +44,7 @@ const enum InputId {
     Address = 'address',
     Offset = 'offset',
     Length = 'length',
+    BytesPerWord = 'word-size',
     WordsPerGroup = 'words-per-group',
     GroupsPerRow = 'groups-per-row',
 }
@@ -54,7 +55,8 @@ interface OptionsForm {
     count: string;
 }
 
-const allowedBytesPerGroup = [1, 2, 4, 8, 16];
+const allowedBytesPerWord = [1, 2, 4, 8, 16];
+const allowedWordsPerGroup = [1, 2, 4, 8, 16];
 const allowedGroupsPerRow = [1, 2, 4, 8, 16, 32];
 
 export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
@@ -220,17 +222,32 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
                                     onSelectionChanged={this.handleColumnActivationChange}
                                 />
                             )}
+                            <h2>Memory Format</h2>
+
+                            <label
+                                htmlFor={InputId.BytesPerWord}
+                                className='advanced-options-label mt-1'
+                            >
+                                Bytes per Word
+                            </label>
+                            <Dropdown
+                                id={InputId.BytesPerWord}
+                                value={this.props.bytesPerWord}
+                                onChange={this.handleAdvancedOptionsDropdownChange}
+                                options={allowedBytesPerWord}
+                                className='advanced-options-dropdown' />
+
                             <label
                                 htmlFor={InputId.WordsPerGroup}
                                 className='advanced-options-label mt-1'
                             >
-                                Bytes per Group
+                                Words per Group
                             </label>
                             <Dropdown
                                 id={InputId.WordsPerGroup}
                                 value={this.props.wordsPerGroup}
                                 onChange={this.handleAdvancedOptionsDropdownChange}
-                                options={allowedBytesPerGroup}
+                                options={allowedWordsPerGroup}
                                 className='advanced-options-dropdown' />
                             <label
                                 htmlFor={InputId.GroupsPerRow}
@@ -304,6 +321,9 @@ export class OptionsWidget extends React.Component<OptionsWidgetProps, {}> {
         const id = event.target.id as InputId;
         const value = event.target.value;
         switch (id) {
+            case InputId.BytesPerWord:
+                this.props.updateRenderOptions({ bytesPerWord: Number(value) });
+                break;
             case InputId.WordsPerGroup:
                 this.props.updateRenderOptions({ wordsPerGroup: Number(value) });
                 break;

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -22,6 +22,7 @@ import {
     logMessageType,
     setOptionsType,
     readMemoryType,
+    setTitleType,
     setMemoryViewSettingsType,
     resetMemoryViewSettingsType,
 } from '../common/messaging';
@@ -39,6 +40,7 @@ import { PrimeReactProvider } from 'primereact/api';
 import 'primeflex/primeflex.css';
 
 export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
+    title: string;
     decorations: Decoration[];
     columns: ColumnStatus[];
 }
@@ -59,6 +61,7 @@ class App extends React.Component<{}, MemoryAppState> {
         columnContributionService.register(new AsciiColumn());
         decorationService.register(variableDecorator);
         this.state = {
+            title: 'Memory',
             memory: undefined,
             memoryReference: '',
             offset: 0,
@@ -78,7 +81,7 @@ class App extends React.Component<{}, MemoryAppState> {
                 const configurable = column.configurable;
                 this.toggleColumn(id, !configurable || !!config.visibleColumns?.includes(id));
             }
-            this.setState(prevState => ({ ...prevState, ...(config as MemoryDisplayConfiguration) }));
+            this.setState(prevState => ({ ...prevState, ...config, title: config.title ?? prevState.title, }));
         });
         messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
     }
@@ -92,9 +95,11 @@ class App extends React.Component<{}, MemoryAppState> {
                 memoryReference={this.state.memoryReference}
                 offset={this.state.offset ?? 0}
                 count={this.state.count}
+                title={this.state.title}
                 updateMemoryArguments={this.updateMemoryState}
                 updateMemoryDisplayConfiguration={this.updateMemoryDisplayConfiguration}
                 resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
+                updateTitle={this.updateTitle}
                 refreshMemory={this.refreshMemory}
                 toggleColumn={this.toggleColumn}
                 fetchMemory={this.fetchMemory}
@@ -109,6 +114,10 @@ class App extends React.Component<{}, MemoryAppState> {
     protected updateMemoryState = (newState: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
     protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
     protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryViewSettingsType, HOST_EXTENSION, undefined);
+    protected updateTitle = (title: string) => {
+        this.setState({ title });
+        messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
+    };
 
     protected async setOptions(options?: Partial<DebugProtocol.ReadMemoryArguments>): Promise<void> {
         messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -44,6 +44,7 @@ export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration 
 }
 
 const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
+    bytesPerWord: 1,
     wordsPerGroup: 1,
     groupsPerRow: 4,
     scrollingBehavior: 'Paginate'
@@ -99,6 +100,7 @@ class App extends React.Component<{}, MemoryAppState> {
                 toggleColumn={this.toggleColumn}
                 fetchMemory={this.fetchMemory}
                 isMemoryFetching={this.state.isMemoryFetching}
+                bytesPerWord={this.state.bytesPerWord}
                 groupsPerRow={this.state.groupsPerRow}
                 wordsPerGroup={this.state.wordsPerGroup}
                 scrollingBehavior={this.state.scrollingBehavior}

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -48,7 +48,9 @@ export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration 
 const MEMORY_DISPLAY_CONFIGURATION_DEFAULTS: MemoryDisplayConfiguration = {
     wordsPerGroup: 1,
     groupsPerRow: 4,
-    scrollingBehavior: 'Paginate'
+    scrollingBehavior: 'Paginate',
+    addressRadix: 16,
+    showRadixPrefix: true,
 };
 
 class App extends React.Component<{}, MemoryAppState> {
@@ -107,6 +109,8 @@ class App extends React.Component<{}, MemoryAppState> {
                 groupsPerRow={this.state.groupsPerRow}
                 wordsPerGroup={this.state.wordsPerGroup}
                 scrollingBehavior={this.state.scrollingBehavior}
+                addressRadix={this.state.addressRadix}
+                showRadixPrefix={this.state.showRadixPrefix}
             />
         </PrimeReactProvider>;
     }

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -73,7 +73,9 @@ export interface FullNodeAttributes extends StylableNodeAttributes {
 }
 
 /** All settings related to memory view that can be specified for the webview from the extension "main". */
-export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDisplayConfiguration { }
+export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDisplayConfiguration {
+    title: string
+}
 
 /** The memory display configuration that can be specified for the memory widget. */
 export interface MemoryDisplayConfiguration {

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -32,7 +32,7 @@ export interface Memory {
 export interface SerializedTableRenderOptions extends MemoryDisplayConfiguration {
     columnOptions: Array<{ label: string, doRender: boolean }>;
     endianness: Endianness;
-    wordSize: number;
+    bytesPerWord: number;
 }
 
 export interface Event<T> {
@@ -77,6 +77,7 @@ export interface MemoryViewSettings extends ColumnVisibilityStatus, MemoryDispla
 
 /** The memory display configuration that can be specified for the memory widget. */
 export interface MemoryDisplayConfiguration {
+    bytesPerWord: number;
     wordsPerGroup: number;
     groupsPerRow: number;
     scrollingBehavior: ScrollingBehavior;

--- a/src/webview/utils/view-types.ts
+++ b/src/webview/utils/view-types.ts
@@ -17,7 +17,7 @@
 import type { DebugProtocol } from '@vscode/debugprotocol';
 import deepequal from 'fast-deep-equal';
 import type * as React from 'react';
-import { areRangesEqual, BigIntMemoryRange } from '../../common/memory-range';
+import { areRangesEqual, BigIntMemoryRange, Radix } from '../../common/memory-range';
 
 export enum Endianness {
     Little = 'Little Endian',
@@ -82,6 +82,8 @@ export interface MemoryDisplayConfiguration {
     wordsPerGroup: number;
     groupsPerRow: number;
     scrollingBehavior: ScrollingBehavior;
+    addressRadix: Radix;
+    showRadixPrefix: boolean;
 }
 export type ScrollingBehavior = 'Paginate' | 'Infinite';
 


### PR DESCRIPTION
#### What it does

* Introduces user option for bytes per word (VS Code settings & per view)
* Rename "Bytes per Group" into "Words per Group"
* Add right margin to groups

Fixes https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/74
Fixes https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/issues/75

#### How to test
* Start debug session and open two memory view instances
* Verify there are separating spaces between groups
* Change bytes per word and check it is applied correctly to the memory data in the individual views
* Use the reset settings button in the options and verify they are reset correctly
* Change the VS Code settings regarding "Bytes per Word"
* Use the reset settings button again to check the new settings are applied

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
