### PR TITLE
Introduce Data Breakpoints

### DIFF
--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.memory-inspector-table tr>th:not(.content-width-fit),
-.memory-inspector-table tr>td:not(.content-width-fit) {
+.memory-inspector-table tr > th:not(.content-width-fit),
+.memory-inspector-table tr > td:not(.content-width-fit) {
   min-width: 120px;
 }
 
-.memory-inspector-table tr>td {
+.memory-inspector-table tr > td {
   font-family: var(--vscode-editor-font-family);
 }
 
@@ -61,10 +61,12 @@
 }
 
 .memory-inspector-table tbody .address-status.codicon-debug-stackframe {
-  color: var(--vscode-debugIcon-breakpointCurrentStackframeForeground)
+  color: var(--vscode-debugIcon-breakpointCurrentStackframeForeground);
 }
 
-.memory-inspector-table tbody .address-status.codicon-debug-breakpoint.codicon-debug-stackframe:after {
+.memory-inspector-table
+  tbody
+  .address-status.codicon-debug-breakpoint.codicon-debug-stackframe:after {
   content: "\ea71";
   position: absolute;
   left: 3px;
@@ -135,7 +137,7 @@
 
 .memory-inspector-table span.p-column-resizer {
   border-right: 2px solid var(--vscode-editor-lineHighlightBorder);
-  transition: border-right .1s ease-out;
+  transition: border-right 0.1s ease-out;
 }
 
 .memory-inspector-table span.p-column-resizer:hover {
@@ -143,8 +145,7 @@
 }
 
 .memory-inspector-table .p-column-resizer-helper {
-  margin-top: 32px !important;
-  /* avoid overlap with top 'Load more' widget */
+  margin-top: 32px !important; /* avoid overlap with top 'Load more' widget */
   width: 2px;
 }
 
@@ -189,12 +190,12 @@
 }
 
 /* Colors for the hover fields */
-.memory-hover .label-value-pair>.label {
+.memory-hover .label-value-pair > .label {
   color: var(--vscode-debugTokenExpression-string);
   white-space: nowrap;
 }
 
-.memory-hover .label-value-pair>.value {
+.memory-hover .label-value-pair > .value {
   color: var(--vscode-debugTokenExpression-number);
 }
 
@@ -218,8 +219,7 @@
 .byte-group {
   font-family: var(--vscode-editor-font-family);
   margin-right: 2px;
-  padding: 0 1px;
-  /* we use this padding to balance out the 2px that are needed for the editing */
+  padding: 0 1px; /* we use this padding to balance out the 2px that are needed for the editing */
 }
 
 .byte-group:last-child {
@@ -229,8 +229,7 @@
 .byte-group:has(> .data-edit) {
   outline: 1px solid var(--vscode-inputOption-activeBorder);
   outline-offset: 1px;
-  padding: 0px;
-  /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
+  padding: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
 }
 
 .data-edit {

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -14,12 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.memory-inspector-table tr > th:not(.content-width-fit),
-.memory-inspector-table tr > td:not(.content-width-fit) {
+.memory-inspector-table tr>th:not(.content-width-fit),
+.memory-inspector-table tr>td:not(.content-width-fit) {
   min-width: 120px;
 }
 
-.memory-inspector-table tr > td {
+.memory-inspector-table tr>td {
   font-family: var(--vscode-editor-font-family);
 }
 
@@ -37,22 +37,43 @@
 }
 
 .memory-inspector-table .data-breakpoint.data-breakpoint-external {
-  outline-style: dashed;  
+  outline-style: dashed;
 }
 
 .memory-inspector-table tbody .column-address {
   position: relative;
 }
 
-.memory-inspector-table tbody tr:has(.data-breakpoint) .column-address::before {
-  content: '';
-  border-radius: 100%;
-  height: 6px;
-  width: 6px;
-  background-color: var(--vscode-debugIcon-breakpointForeground);
+.memory-inspector-table tbody .address-status {
   position: absolute;
-  left: 4px;
-  top: calc(50% - 4px);
+  left: -1px;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
+.memory-inspector-table tbody .address-status.codicon {
+  font-size: 12px;
+}
+
+.memory-inspector-table tbody .address-status.codicon-debug-breakpoint {
+  color: var(--vscode-debugIcon-breakpointForeground);
+}
+
+.memory-inspector-table tbody .address-status.codicon-debug-stackframe {
+  color: var(--vscode-debugIcon-breakpointCurrentStackframeForeground)
+}
+
+.memory-inspector-table tbody .address-status.codicon-debug-breakpoint.codicon-debug-stackframe:after {
+  content: "\ea71";
+  position: absolute;
+  left: 3px;
+  font-size: 6px;
+  color: var(--vscode-debugIcon-breakpointForeground);
+}
+
+.memory-inspector-table tbody .debug-hit {
+  outline-color: var(--vscode-debugIcon-breakpointCurrentStackframeForeground);
 }
 
 /* == MoreMemorySelect == */
@@ -122,7 +143,8 @@
 }
 
 .memory-inspector-table .p-column-resizer-helper {
-  margin-top: 32px !important; /* avoid overlap with top 'Load more' widget */
+  margin-top: 32px !important;
+  /* avoid overlap with top 'Load more' widget */
   width: 2px;
 }
 
@@ -135,7 +157,7 @@
 /* Basic hover formatting (copied from Monaco hovers) */
 .memory-hover {
   min-width: fit-content;
-  max-width: var(--vscode-hover-maxWidth,500px);
+  max-width: var(--vscode-hover-maxWidth, 500px);
   border: 1px solid var(--vscode-editorHoverWidget-border);
   border-radius: 3px;
 
@@ -151,23 +173,27 @@
   border-collapse: collapse;
   border-style: hidden;
 }
+
 .memory-hover table caption {
   padding: 4px;
   border-bottom: 1px solid var(--vscode-editorHoverWidget-border);
 }
+
 .memory-hover td {
   border: 1px solid var(--vscode-editorHoverWidget-border);
   padding: 2px 8px;
 }
+
 .memory-hover td:first-child {
   text-align: right;
 }
 
 /* Colors for the hover fields */
 .memory-hover .label-value-pair>.label {
-    color: var(--vscode-debugTokenExpression-string);
-    white-space: nowrap;
+  color: var(--vscode-debugTokenExpression-string);
+  white-space: nowrap;
 }
+
 .memory-hover .label-value-pair>.value {
   color: var(--vscode-debugTokenExpression-number);
 }
@@ -176,9 +202,11 @@
 .memory-hover .address-hover .primary {
   background-color: var(--vscode-list-hoverBackground);
 }
+
 .memory-hover table caption {
   color: var(--vscode-symbolIcon-variableForeground);
 }
+
 .memory-hover .address-hover .value.utf8,
 .memory-hover .data-hover .value.utf8,
 .memory-hover .variable-hover .value.type {
@@ -190,7 +218,8 @@
 .byte-group {
   font-family: var(--vscode-editor-font-family);
   margin-right: 2px;
-  padding: 0 1px; /* we use this padding to balance out the 2px that are needed for the editing */
+  padding: 0 1px;
+  /* we use this padding to balance out the 2px that are needed for the editing */
 }
 
 .byte-group:last-child {
@@ -200,7 +229,8 @@
 .byte-group:has(> .data-edit) {
   outline: 1px solid var(--vscode-inputOption-activeBorder);
   outline-offset: 1px;
-  padding: 0px; /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
+  padding: 0px;
+  /* editing takes two more pixels cause the input field will cut off the characters otherwise. */
 }
 
 .data-edit {

--- a/media/memory-table.css
+++ b/media/memory-table.css
@@ -31,6 +31,30 @@
   border-bottom: 1px dotted var(--vscode-editorHoverWidget-border);
 }
 
+.memory-inspector-table .data-breakpoint {
+  outline: 1px solid var(--vscode-debugIcon-breakpointForeground);
+  outline-offset: 1px;
+}
+
+.memory-inspector-table .data-breakpoint.data-breakpoint-external {
+  outline-style: dashed;  
+}
+
+.memory-inspector-table tbody .column-address {
+  position: relative;
+}
+
+.memory-inspector-table tbody tr:has(.data-breakpoint) .column-address::before {
+  content: '';
+  border-radius: 100%;
+  height: 6px;
+  width: 6px;
+  background-color: var(--vscode-debugIcon-breakpointForeground);
+  position: absolute;
+  left: 4px;
+  top: calc(50% - 4px);
+}
+
 /* == MoreMemorySelect == */
 
 .bytes-select {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,36 @@
         "category": "Memory"
       },
       {
+        "command": "memory-inspector.data-breakpoint.set.read",
+        "title": "Break on Value Read",
+        "enablement": "memory-inspector.canWrite",
+        "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.data-breakpoint.set.readWrite",
+        "title": "Break on Value Access",
+        "enablement": "memory-inspector.canWrite",
+        "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.data-breakpoint.set.write",
+        "title": "Break on Value Change",
+        "enablement": "memory-inspector.canWrite",
+        "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.data-breakpoint.remove",
+        "title": "Remove Breakpoint",
+        "enablement": "memory-inspector.canWrite",
+        "category": "Memory"
+      },
+      {
+        "command": "memory-inspector.data-breakpoint.remove-all",
+        "title": "Remove All Breakpoints",
+        "enablement": "memory-inspector.canWrite",
+        "category": "Memory"
+      },
+      {
         "command": "memory-inspector.toggle-variables-column",
         "title": "Toggle Variables Column",
         "category": "Memory",
@@ -214,6 +244,31 @@
           "command": "memory-inspector.go-to-value",
           "group": "display@7",
           "when": "webviewId === memory-inspector.memory && memory-inspector.variable.isPointer"
+        },
+        {
+          "command": "memory-inspector.data-breakpoint.set.read",
+          "group": "breakpoints@1",
+          "when": "webviewId === memory-inspector.memory && memory-inspector.breakpoint.isBreakable"
+        },
+        {
+          "command": "memory-inspector.data-breakpoint.set.write",
+          "group": "breakpoints@2",
+          "when": "webviewId === memory-inspector.memory && memory-inspector.breakpoint.isBreakable"
+        },
+        {
+          "command": "memory-inspector.data-breakpoint.set.readWrite",
+          "group": "breakpoints@3",
+          "when": "webviewId === memory-inspector.memory && memory-inspector.breakpoint.isBreakable"
+        },
+        {
+          "command": "memory-inspector.data-breakpoint.remove",
+          "group": "breakpoints@4",
+          "when": "webviewId === memory-inspector.memory && memory-inspector.breakpoint.type === 'internal'"
+        },
+        {
+          "command": "memory-inspector.data-breakpoint.remove-all",
+          "group": "breakpoints@5",
+          "when": "webviewId === memory-inspector.memory && memory-inspector.breakpoint.type === 'internal'"
         }
       ]
     },

--- a/src/common/breakpoint.ts
+++ b/src/common/breakpoint.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { DebugRequestTypes } from './debug-requests';
+
+export interface DataBreakpoints {
+    external: DebugProtocol.DataBreakpoint[],
+    internal: DebugProtocol.DataBreakpoint[]
+}
+
+export type TrackedBreakpointType = 'internal' | 'external';
+
+export type SetDataBreakpointsArguments = DebugRequestTypes['setDataBreakpoints'][0];
+export type SetDataBreakpointsResult = DebugRequestTypes['setDataBreakpoints'][1];

--- a/src/common/breakpoint.ts
+++ b/src/common/breakpoint.ts
@@ -17,7 +17,7 @@
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { DebugRequestTypes } from './debug-requests';
 
-export interface TrackedBreakpoint {
+export interface TrackedDataBreakpoint {
     type: TrackedBreakpointType;
     breakpoint: DebugProtocol.DataBreakpoint;
     /**
@@ -26,18 +26,20 @@ export interface TrackedBreakpoint {
     response: DebugProtocol.SetDataBreakpointsResponse['body']['breakpoints'][0]
 }
 
-export interface TrackedBreakpoints {
+export interface TrackedDataBreakpoints {
     /**
      * Breakpoints set from external contributors.
      */
-    external: TrackedBreakpoint[],
+    external: TrackedDataBreakpoint[],
     /**
      * Breakpoints set from us.
      */
-    internal: TrackedBreakpoint[]
+    internal: TrackedDataBreakpoint[]
 }
 
 export type TrackedBreakpointType = 'internal' | 'external';
 
+export type DataBreakpointInfoArguments = DebugRequestTypes['dataBreakpointInfo'][0];
+export type DataBreakpointInfoResult = DebugRequestTypes['dataBreakpointInfo'][1];
 export type SetDataBreakpointsArguments = DebugRequestTypes['setDataBreakpoints'][0];
 export type SetDataBreakpointsResult = DebugRequestTypes['setDataBreakpoints'][1];

--- a/src/common/breakpoint.ts
+++ b/src/common/breakpoint.ts
@@ -17,9 +17,24 @@
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { DebugRequestTypes } from './debug-requests';
 
-export interface DataBreakpoints {
-    external: DebugProtocol.DataBreakpoint[],
-    internal: DebugProtocol.DataBreakpoint[]
+export interface TrackedBreakpoint {
+    type: TrackedBreakpointType;
+    breakpoint: DebugProtocol.DataBreakpoint;
+    /**
+     * The respective response for the breakpoint.
+     */
+    response: DebugProtocol.SetDataBreakpointsResponse['body']['breakpoints'][0]
+}
+
+export interface TrackedBreakpoints {
+    /**
+     * Breakpoints set from external contributors.
+     */
+    external: TrackedBreakpoint[],
+    /**
+     * Breakpoints set from us.
+     */
+    internal: TrackedBreakpoint[]
 }
 
 export type TrackedBreakpointType = 'internal' | 'external';

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -60,16 +60,28 @@ export function isDebugEvaluateArguments(args: DebugProtocol.EvaluateArguments |
 }
 
 export function isDebugRequest<K extends keyof DebugRequestTypes>(command: K, message: unknown): message is DebugRequest<K, DebugRequestTypes[K][0]> {
-    const assumed = message ? message as DebugProtocol.Request : undefined;
-    return !!assumed && assumed.type === 'request' && assumed.command === command;
+    return isDebugRequestType(message) && message.command === command;
 }
 
 export function isDebugResponse<K extends keyof DebugRequestTypes>(command: K, message: unknown): message is DebugResponse<K, DebugRequestTypes[K][1]> {
-    const assumed = message ? message as DebugProtocol.Response : undefined;
-    return !!assumed && assumed.type === 'response' && assumed.command === command;
+    return isDebugResponseType(message) && message.command === command;
 }
 
 export function isDebugEvent<K extends keyof DebugEvents>(event: K, message: unknown): message is DebugEvents[K] {
+    return isDebugEventType(message) && message.event === event;
+}
+
+export function isDebugRequestType(message: unknown): message is DebugProtocol.Request {
+    const assumed = message ? message as DebugProtocol.Request : undefined;
+    return !!assumed && assumed.type === 'request';
+}
+
+export function isDebugResponseType(message: unknown): message is DebugProtocol.Response {
+    const assumed = message ? message as DebugProtocol.Response : undefined;
+    return !!assumed && assumed.type === 'response';
+}
+
+export function isDebugEventType(message: unknown): message is DebugProtocol.Event {
     const assumed = message ? message as DebugProtocol.Event : undefined;
-    return !!assumed && assumed.type === 'event' && assumed.event === event;
+    return !!assumed && assumed.type === 'event';
 }

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -25,6 +25,7 @@ export interface DebugRequestTypes {
     'scopes': [DebugProtocol.ScopesArguments, DebugProtocol.ScopesResponse['body']]
     'variables': [DebugProtocol.VariablesArguments, DebugProtocol.VariablesResponse['body']]
     'writeMemory': [DebugProtocol.WriteMemoryArguments, DebugProtocol.WriteMemoryResponse['body']]
+    'setDataBreakpoints': [DebugProtocol.SetDataBreakpointsArguments, DebugProtocol.SetDataBreakpointsResponse['body']]
 }
 
 export interface DebugEvents {

--- a/src/common/debug-requests.ts
+++ b/src/common/debug-requests.ts
@@ -25,6 +25,7 @@ export interface DebugRequestTypes {
     'scopes': [DebugProtocol.ScopesArguments, DebugProtocol.ScopesResponse['body']]
     'variables': [DebugProtocol.VariablesArguments, DebugProtocol.VariablesResponse['body']]
     'writeMemory': [DebugProtocol.WriteMemoryArguments, DebugProtocol.WriteMemoryResponse['body']]
+    'dataBreakpointInfo': [DebugProtocol.DataBreakpointInfoArguments, DebugProtocol.DataBreakpointInfoResponse['body']]
     'setDataBreakpoints': [DebugProtocol.SetDataBreakpointsArguments, DebugProtocol.SetDataBreakpointsResponse['body']]
 }
 

--- a/src/common/memory-range.ts
+++ b/src/common/memory-range.ts
@@ -108,6 +108,7 @@ export interface VariableMetadata {
     type?: string;
     /** If applicable, a string representation of the variable's value */
     value?: string;
+    parentVariablesReference?: number;
     isPointer?: boolean;
 }
 

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -18,7 +18,7 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { NotificationType, RequestType } from 'vscode-messenger-common';
 import { URI } from 'vscode-uri';
 import { VariablesView } from '../plugin/external-views';
-import type { TrackedBreakpoints } from './breakpoint';
+import type { TrackedDataBreakpoints } from './breakpoint';
 import { DebugEvents, DebugRequestTypes } from './debug-requests';
 import type { VariableRange, WrittenMemory } from './memory-range';
 import { MemoryViewSettings } from './webview-configuration';
@@ -56,7 +56,7 @@ export const resetMemoryViewSettingsType: NotificationType<void> = { method: 're
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
 export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
-export const setTrackedBreakpointType: NotificationType<TrackedBreakpoints> = { method: 'setTrackedBreakpoints' };
+export const setTrackedBreakpointType: NotificationType<TrackedDataBreakpoints> = { method: 'setTrackedBreakpoints' };
 export const notifyStoppedType: NotificationType<StoppedEvent> = { method: 'notifyStoppedType' };
 export const notifyContinuedType: NotificationType<ContinuedEvent> = { method: 'notifyContinuedType' };
 

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -18,6 +18,7 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { NotificationType, RequestType } from 'vscode-messenger-common';
 import { URI } from 'vscode-uri';
 import { VariablesView } from '../plugin/external-views';
+import { DataBreakpoints } from './breakpoint';
 import { DebugRequestTypes } from './debug-requests';
 import type { VariableRange, WrittenMemory } from './memory-range';
 import { MemoryViewSettings } from './webview-configuration';
@@ -52,6 +53,7 @@ export const resetMemoryViewSettingsType: NotificationType<void> = { method: 're
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
 export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
+export const setDataBreakpointType: NotificationType<DataBreakpoints> = { method: 'setDataBreakpoint' };
 
 // Requests
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };

--- a/src/common/messaging.ts
+++ b/src/common/messaging.ts
@@ -18,8 +18,8 @@ import type { DebugProtocol } from '@vscode/debugprotocol';
 import type { NotificationType, RequestType } from 'vscode-messenger-common';
 import { URI } from 'vscode-uri';
 import { VariablesView } from '../plugin/external-views';
-import { DataBreakpoints } from './breakpoint';
-import { DebugRequestTypes } from './debug-requests';
+import type { TrackedBreakpoints } from './breakpoint';
+import { DebugEvents, DebugRequestTypes } from './debug-requests';
 import type { VariableRange, WrittenMemory } from './memory-range';
 import { MemoryViewSettings } from './webview-configuration';
 import { WebviewContext } from './webview-context';
@@ -32,6 +32,9 @@ export type ReadMemoryResult = DebugRequestTypes['readMemory'][1];
 
 export type WriteMemoryArguments = DebugRequestTypes['writeMemory'][0];
 export type WriteMemoryResult = DebugRequestTypes['writeMemory'][1];
+
+export type StoppedEvent = DebugEvents['stopped'];
+export type ContinuedEvent = DebugEvents['continued'];
 
 export type StoreMemoryArguments = MemoryOptions & { proposedOutputName?: string } | VariablesView.IVariablesContext | WebviewContext;
 export type StoreMemoryResult = void;
@@ -53,7 +56,9 @@ export const resetMemoryViewSettingsType: NotificationType<void> = { method: 're
 export const setTitleType: NotificationType<string> = { method: 'setTitle' };
 export const memoryWrittenType: NotificationType<WrittenMemory> = { method: 'memoryWritten' };
 export const sessionContextChangedType: NotificationType<SessionContext> = { method: 'sessionContextChanged' };
-export const setDataBreakpointType: NotificationType<DataBreakpoints> = { method: 'setDataBreakpoint' };
+export const setTrackedBreakpointType: NotificationType<TrackedBreakpoints> = { method: 'setTrackedBreakpoints' };
+export const notifyStoppedType: NotificationType<StoppedEvent> = { method: 'notifyStoppedType' };
+export const notifyContinuedType: NotificationType<ContinuedEvent> = { method: 'notifyContinuedType' };
 
 // Requests
 export const setOptionsType: RequestType<MemoryOptions, void> = { method: 'setOptions' };

--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -15,7 +15,8 @@
  ********************************************************************************/
 
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import { Endianness, VariableMetadata } from './memory-range';
+import { Endianness } from './manifest';
+import { VariableMetadata } from './memory-range';
 import { ReadMemoryArguments } from './messaging';
 
 export interface WebviewContext {
@@ -36,6 +37,15 @@ export interface WebviewCellContext extends WebviewContext {
 
 export interface WebviewVariableContext extends WebviewCellContext {
     variable?: VariableMetadata
+}
+
+export interface WebviewGroupContext extends WebviewCellContext {
+    memoryData?: {
+        group: {
+            startAddress: string;
+            length: number;
+        }
+    }
 }
 
 /**
@@ -59,6 +69,14 @@ export function isWebviewContext(args: WebviewContext | unknown): args is Webvie
         && typeof assumed.webviewSection === 'string' && typeof assumed.showAsciiColumn === 'boolean' && typeof assumed.showVariablesColumn === 'boolean'
         && typeof assumed.showRadixPrefix === 'boolean' && typeof assumed.activeReadArguments?.count === 'number' && typeof assumed.activeReadArguments?.offset === 'number'
         && typeof assumed.activeReadArguments?.memoryReference === 'string';
+}
+
+export function isWebviewGroupContext(args: WebviewVariableContext | unknown): args is Required<WebviewGroupContext> {
+    const assumed = args ? args as WebviewGroupContext : undefined;
+    return !!assumed && isWebviewContext(args)
+        && !!assumed.memoryData
+        && (typeof assumed.memoryData.group.startAddress === 'string')
+        && (typeof assumed.memoryData.group.length === 'number');
 }
 
 export function isWebviewVariableContext(args: WebviewVariableContext | unknown): args is Required<WebviewVariableContext> {

--- a/src/common/webview-context.ts
+++ b/src/common/webview-context.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import { VariableMetadata } from './memory-range';
+import { Endianness, VariableMetadata } from './memory-range';
 import { ReadMemoryArguments } from './messaging';
 
 export interface WebviewContext {
@@ -24,6 +24,8 @@ export interface WebviewContext {
     showAsciiColumn: boolean
     showVariablesColumn: boolean,
     showRadixPrefix: boolean,
+    endianness: Endianness,
+    bytesPerMau: number,
     activeReadArguments: Required<ReadMemoryArguments>
 }
 

--- a/src/entry-points/browser/extension.ts
+++ b/src/entry-points/browser/extension.ts
@@ -17,6 +17,8 @@
 import * as vscode from 'vscode';
 import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
+import { BreakpointProvider } from '../../plugin/breakpoints/breakpoint-provider';
+import { BreakpointTracker } from '../../plugin/breakpoints/breakpoint-tracker';
 import { ContextTracker } from '../../plugin/context-tracker';
 import { MemoryProvider } from '../../plugin/memory-provider';
 import { MemoryStorage } from '../../plugin/memory-storage';
@@ -27,8 +29,10 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Adapte
     const registry = new AdapterRegistry();
     const sessionTracker = new SessionTracker();
     new ContextTracker(sessionTracker);
+    const breakpointTracker = new BreakpointTracker(sessionTracker);
+    const breakpointProvider = new BreakpointProvider(sessionTracker, breakpointTracker);
     const memoryProvider = new MemoryProvider(registry, sessionTracker);
-    const memoryView = new MemoryWebview(context.extensionUri, memoryProvider, sessionTracker);
+    const memoryView = new MemoryWebview(context.extensionUri, memoryProvider, sessionTracker, breakpointTracker, breakpointProvider);
     const memoryStorage = new MemoryStorage(memoryProvider);
     const cAdapter = new CAdapter(registry);
 

--- a/src/entry-points/desktop/extension.ts
+++ b/src/entry-points/desktop/extension.ts
@@ -17,6 +17,8 @@
 import * as vscode from 'vscode';
 import { AdapterRegistry } from '../../plugin/adapter-registry/adapter-registry';
 import { CAdapter } from '../../plugin/adapter-registry/c-adapter';
+import { BreakpointProvider } from '../../plugin/breakpoints/breakpoint-provider';
+import { BreakpointTracker } from '../../plugin/breakpoints/breakpoint-tracker';
 import { ContextTracker } from '../../plugin/context-tracker';
 import { MemoryProvider } from '../../plugin/memory-provider';
 import { MemoryStorage } from '../../plugin/memory-storage';
@@ -27,8 +29,10 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Adapte
     const registry = new AdapterRegistry();
     const sessionTracker = new SessionTracker();
     new ContextTracker(sessionTracker);
+    const breakpointTracker = new BreakpointTracker(sessionTracker);
+    const breakpointProvider = new BreakpointProvider(sessionTracker, breakpointTracker);
     const memoryProvider = new MemoryProvider(registry, sessionTracker);
-    const memoryView = new MemoryWebview(context.extensionUri, memoryProvider, sessionTracker);
+    const memoryView = new MemoryWebview(context.extensionUri, memoryProvider, sessionTracker, breakpointTracker, breakpointProvider);
     const memoryStorage = new MemoryStorage(memoryProvider);
     const cAdapter = new CAdapter(registry);
 

--- a/src/plugin/adapter-registry/adapter-capabilities.ts
+++ b/src/plugin/adapter-registry/adapter-capabilities.ts
@@ -108,7 +108,7 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
             if (this.isDesiredVariable(parent) && parent.children?.length) {
                 this.logger.debug('Resolving children of', parent.name);
                 parent.children.forEach(child => {
-                    previous.push(this.variableToVariableRange(child, session));
+                    previous.push(this.variableToVariableRange(child, session, parent));
                 });
             } else {
                 this.logger.debug('Ignoring', parent.name);
@@ -122,7 +122,10 @@ export class AdapterVariableTracker implements vscode.DebugAdapterTracker {
         return candidate.presentationHint !== 'registers' && candidate.name !== 'Registers';
     }
 
-    protected variableToVariableRange(_variable: DebugProtocol.Variable, _session: vscode.DebugSession): Promise<VariableRange | undefined> {
+    protected variableToVariableRange(
+        _variable: DebugProtocol.Variable,
+        _session: vscode.DebugSession,
+        _parent: WithChildren<DebugProtocol.Scope | DebugProtocol.Variable>): Promise<VariableRange | undefined> {
         throw new Error('To be implemented by derived classes!');
     }
 

--- a/src/plugin/breakpoints/breakpoint-provider.ts
+++ b/src/plugin/breakpoints/breakpoint-provider.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { SetDataBreakpointsArguments, SetDataBreakpointsResult } from '../../common/breakpoint';
+import { sendRequest } from '../../common/debug-requests';
+import { SessionTracker } from '../session-tracker';
+import { BreakpointTracker } from './breakpoint-tracker';
+
+export class BreakpointProvider {
+
+    constructor(protected readonly sessionTracker: SessionTracker, protected readonly breakpointTracker: BreakpointTracker) {
+        this.breakpointTracker.onSetDataBreakpointResponseEvent(() => {
+            this.setMemoryInspectorDataBreakpoint({
+                breakpoints: this.breakpointTracker.internalDataBreakpoints
+            });
+        });
+    }
+
+    async setMemoryInspectorDataBreakpoint(args: SetDataBreakpointsArguments): Promise<SetDataBreakpointsResult> {
+        const session = this.sessionTracker.assertDebugCapability(this.sessionTracker.activeSession, 'supportsDataBreakpoints', 'set data breakpoint');
+        this.breakpointTracker.notifySetDataBreakpointEnabled = false;
+        const breakpoints = [
+            ...this.breakpointTracker.externalDataBreakpoints,
+            ...args.breakpoints];
+        return sendRequest(session, 'setDataBreakpoints', { breakpoints })
+            .then(response => {
+                const indexOfInternal = response.breakpoints.length - args.breakpoints.length;
+                this.breakpointTracker.setInternal(response.breakpoints.slice(indexOfInternal));
+                return response;
+            }).finally(() => {
+                this.breakpointTracker.notifySetDataBreakpointEnabled = true;
+            });
+    }
+}

--- a/src/plugin/breakpoints/breakpoint-provider.ts
+++ b/src/plugin/breakpoints/breakpoint-provider.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SetDataBreakpointsArguments, SetDataBreakpointsResult } from '../../common/breakpoint';
+import { DataBreakpointInfoArguments, DataBreakpointInfoResult, SetDataBreakpointsArguments, SetDataBreakpointsResult } from '../../common/breakpoint';
 import { sendRequest } from '../../common/debug-requests';
 import { SessionTracker } from '../session-tracker';
 import { BreakpointTracker } from './breakpoint-tracker';
@@ -24,7 +24,7 @@ export class BreakpointProvider {
     constructor(protected readonly sessionTracker: SessionTracker, protected readonly breakpointTracker: BreakpointTracker) {
         this.breakpointTracker.onSetDataBreakpointResponse(() => {
             this.setMemoryInspectorDataBreakpoint({
-                breakpoints: this.breakpointTracker.internalBreakpoints.map(bp => bp.breakpoint)
+                breakpoints: this.breakpointTracker.internalDataBreakpoints.map(bp => bp.breakpoint)
             });
         });
     }
@@ -33,7 +33,7 @@ export class BreakpointProvider {
         const session = this.sessionTracker.assertDebugCapability(this.sessionTracker.activeSession, 'supportsDataBreakpoints', 'set data breakpoint');
         this.breakpointTracker.notifySetDataBreakpointEnabled = false;
         const breakpoints = [
-            ...this.breakpointTracker.externalBreakpoints.map(bp => bp.breakpoint),
+            ...this.breakpointTracker.externalDataBreakpoints.map(bp => bp.breakpoint),
             ...args.breakpoints];
         return sendRequest(session, 'setDataBreakpoints', { breakpoints })
             .then(response => {
@@ -43,5 +43,10 @@ export class BreakpointProvider {
             }).finally(() => {
                 this.breakpointTracker.notifySetDataBreakpointEnabled = true;
             });
+    }
+
+    async dataBreakpointInfo(args: DataBreakpointInfoArguments): Promise<DataBreakpointInfoResult> {
+        const session = this.sessionTracker.assertDebugCapability(this.sessionTracker.activeSession, 'supportsDataBreakpoints', 'data breakpoint info');
+        return sendRequest(session, 'dataBreakpointInfo', args);
     }
 }

--- a/src/plugin/breakpoints/breakpoint-provider.ts
+++ b/src/plugin/breakpoints/breakpoint-provider.ts
@@ -22,9 +22,9 @@ import { BreakpointTracker } from './breakpoint-tracker';
 export class BreakpointProvider {
 
     constructor(protected readonly sessionTracker: SessionTracker, protected readonly breakpointTracker: BreakpointTracker) {
-        this.breakpointTracker.onSetDataBreakpointResponseEvent(() => {
+        this.breakpointTracker.onSetDataBreakpointResponse(() => {
             this.setMemoryInspectorDataBreakpoint({
-                breakpoints: this.breakpointTracker.internalDataBreakpoints
+                breakpoints: this.breakpointTracker.internalBreakpoints.map(bp => bp.breakpoint)
             });
         });
     }
@@ -33,7 +33,7 @@ export class BreakpointProvider {
         const session = this.sessionTracker.assertDebugCapability(this.sessionTracker.activeSession, 'supportsDataBreakpoints', 'set data breakpoint');
         this.breakpointTracker.notifySetDataBreakpointEnabled = false;
         const breakpoints = [
-            ...this.breakpointTracker.externalDataBreakpoints,
+            ...this.breakpointTracker.externalBreakpoints.map(bp => bp.breakpoint),
             ...args.breakpoints];
         return sendRequest(session, 'setDataBreakpoints', { breakpoints })
             .then(response => {

--- a/src/plugin/breakpoints/breakpoint-tracker.ts
+++ b/src/plugin/breakpoints/breakpoint-tracker.ts
@@ -1,0 +1,128 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DebugProtocol } from '@vscode/debugprotocol';
+import * as vscode from 'vscode';
+import { DataBreakpoints } from '../../common/breakpoint';
+import { isDebugRequest, isDebugResponse } from '../../common/debug-requests';
+import { SessionTracker } from '../session-tracker';
+
+export interface TrackedBreakpoint {
+    breakpoint: DebugProtocol.DataBreakpoint;
+    response: DebugProtocol.SetDataBreakpointsResponse['body']['breakpoints'][0]
+}
+
+export interface TrackedBreakpoints {
+    external: TrackedBreakpoint[],
+    internal: TrackedBreakpoint[]
+}
+
+export class BreakpointTracker {
+    protected _dataBreakpoints: TrackedBreakpoints = { external: [], internal: [] };
+    protected dataBreakpointsRequest: Record<number, DebugProtocol.SetDataBreakpointsRequest> = {};
+
+    private onDataBreakpointsChanged = new vscode.EventEmitter<DataBreakpoints>();
+    readonly onDataBreakpointChangedEvent = this.onDataBreakpointsChanged.event;
+
+    private onSetDataBreakpointResponse = new vscode.EventEmitter<DebugProtocol.SetDataBreakpointsResponse>();
+    readonly onSetDataBreakpointResponseEvent = this.onSetDataBreakpointResponse.event;
+
+    notifySetDataBreakpointEnabled = true;
+
+    get dataBreakpoints(): DataBreakpoints {
+        return {
+            external: this.externalDataBreakpoints,
+            internal: this.internalDataBreakpoints
+        };
+    }
+
+    get internalDataBreakpoints(): DebugProtocol.DataBreakpoint[] {
+        return [...this._dataBreakpoints.internal.map(bp => bp.breakpoint)];
+    }
+
+    get externalDataBreakpoints(): DebugProtocol.DataBreakpoint[] {
+        return [...this._dataBreakpoints.external.map(bp => bp.breakpoint)];
+    }
+
+    constructor(protected sessionTracker: SessionTracker) {
+        this.sessionTracker.onSessionRequest(event => this.onSessionRequest(event));
+        this.sessionTracker.onSessionResponse(event => this.onSessionResponse(event));
+    }
+
+    setInternal(response: DebugProtocol.SetDataBreakpointsResponse['body']['breakpoints']): void {
+        this._dataBreakpoints.internal = [];
+
+        const { external, internal } = this._dataBreakpoints;
+        const ids = response.map(bp => bp.id);
+        for (let i = 0; i < external.length; i++) {
+            const tbp = external[i];
+            if (ids.includes(tbp.response.id)) {
+                internal.push(tbp);
+            }
+        }
+
+        this._dataBreakpoints.external = external.filter(tbp => !ids.includes(tbp.response.id));
+        this.fireDataBreakpoints();
+    }
+
+    protected onSessionRequest(event: DebugProtocol.Request): void {
+        if (!this.sessionTracker.isActive) {
+            return;
+        }
+
+        if (isDebugRequest('setDataBreakpoints', event)) {
+            this.dataBreakpointsRequest[event.seq] = event;
+        }
+    }
+
+    protected onSessionResponse(event: DebugProtocol.Response): void {
+        if (!this.sessionTracker.isActive) {
+            return;
+        }
+
+        if (isDebugResponse('setDataBreakpoints', event)) {
+            this._dataBreakpoints.external = [];
+
+            const { external } = this._dataBreakpoints;
+
+            const request = this.dataBreakpointsRequest[event.request_seq];
+            if (request) {
+                if (event.success) {
+                    for (let i = 0; i < event.body.breakpoints.length; i++) {
+                        const response = event.body.breakpoints[i];
+                        if (response.verified) {
+                            external.push({
+                                breakpoint: request.arguments.breakpoints[i],
+                                response
+                            });
+                        }
+                    }
+                }
+
+                delete this.dataBreakpointsRequest[request.seq];
+            }
+
+            if (this.notifySetDataBreakpointEnabled) {
+                this.onSetDataBreakpointResponse.fire(event);
+                this.fireDataBreakpoints();
+            }
+        }
+    }
+
+    protected fireDataBreakpoints(): void {
+        this.onDataBreakpointsChanged.fire(this.dataBreakpoints);
+    }
+}

--- a/src/plugin/breakpoints/breakpoint-tracker.ts
+++ b/src/plugin/breakpoints/breakpoint-tracker.ts
@@ -16,7 +16,7 @@
 
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
-import { TrackedBreakpoint, TrackedBreakpoints } from '../../common/breakpoint';
+import { SetDataBreakpointsResult, TrackedBreakpoint, TrackedBreakpoints } from '../../common/breakpoint';
 import { isDebugRequest, isDebugResponse } from '../../common/debug-requests';
 import { isSessionEvent, SessionContinuedEvent, SessionEvent, SessionRequest, SessionResponse, SessionStoppedEvent, SessionTracker } from '../session-tracker';
 
@@ -61,11 +61,11 @@ export class BreakpointTracker {
         this.sessionTracker.onSessionResponse(event => this.onSessionResponse(event));
     }
 
-    setInternal(response: DebugProtocol.SetDataBreakpointsResponse['body']['breakpoints']): void {
+    setInternal(internalBreakpoints: SetDataBreakpointsResult['breakpoints']): void {
         this._dataBreakpoints.internal = [];
 
         const { external, internal } = this._dataBreakpoints;
-        const ids = response.map(bp => bp.id);
+        const ids = internalBreakpoints.map(bp => bp.id);
         for (let i = 0; i < external.length; i++) {
             const tbp = external[i];
             if (ids.includes(tbp.response.id)) {
@@ -84,6 +84,8 @@ export class BreakpointTracker {
         }
 
         if (isSessionEvent('stopped', event)) {
+            // TODO: Only for demo purposes
+            // Reason: The debugger does not set the hitBreakpointIds property
             const demoEvent: SessionStoppedEvent = {
                 ...event,
                 data: {
@@ -108,7 +110,6 @@ export class BreakpointTracker {
         }
 
         const { request } = event;
-
         if (isDebugRequest('setDataBreakpoints', request)) {
             this.dataBreakpointsRequest[request.seq] = request;
         }
@@ -120,7 +121,6 @@ export class BreakpointTracker {
         }
 
         const { response } = event;
-
         if (isDebugResponse('setDataBreakpoints', response)) {
             this._dataBreakpoints.external = [];
 

--- a/src/plugin/breakpoints/breakpoint-tracker.ts
+++ b/src/plugin/breakpoints/breakpoint-tracker.ts
@@ -16,16 +16,16 @@
 
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
-import { SetDataBreakpointsResult, TrackedBreakpoint, TrackedBreakpoints } from '../../common/breakpoint';
+import { SetDataBreakpointsResult, TrackedDataBreakpoint, TrackedDataBreakpoints } from '../../common/breakpoint';
 import { isDebugRequest, isDebugResponse } from '../../common/debug-requests';
 import { isSessionEvent, SessionContinuedEvent, SessionEvent, SessionRequest, SessionResponse, SessionStoppedEvent, SessionTracker } from '../session-tracker';
 
 export class BreakpointTracker {
-    protected _dataBreakpoints: TrackedBreakpoints = { external: [], internal: [] };
+    protected _dataBreakpoints: TrackedDataBreakpoints = { external: [], internal: [] };
     protected _stoppedEvent?: SessionStoppedEvent;
     protected dataBreakpointsRequest: Record<number, DebugProtocol.SetDataBreakpointsRequest> = {};
 
-    protected _onBreakpointsChanged = new vscode.EventEmitter<TrackedBreakpoints>();
+    protected _onBreakpointsChanged = new vscode.EventEmitter<TrackedDataBreakpoints>();
     readonly onBreakpointChanged = this._onBreakpointsChanged.event;
 
     protected _onSetDataBreakpointResponse = new vscode.EventEmitter<DebugProtocol.SetDataBreakpointsResponse>();
@@ -39,15 +39,15 @@ export class BreakpointTracker {
 
     notifySetDataBreakpointEnabled = true;
 
-    get breakpoints(): TrackedBreakpoints {
+    get dataBreakpoints(): TrackedDataBreakpoints {
         return this._dataBreakpoints;
     }
 
-    get internalBreakpoints(): TrackedBreakpoint[] {
+    get internalDataBreakpoints(): TrackedDataBreakpoint[] {
         return this._dataBreakpoints.internal;
     }
 
-    get externalBreakpoints(): TrackedBreakpoint[] {
+    get externalDataBreakpoints(): TrackedDataBreakpoint[] {
         return this._dataBreakpoints.external;
     }
 
@@ -92,7 +92,7 @@ export class BreakpointTracker {
                     ...event.data,
                     body: {
                         ...event.data.body,
-                        hitBreakpointIds: this.externalBreakpoints.map(bp => bp.response.id ?? -1)
+                        hitBreakpointIds: this.externalDataBreakpoints.map(bp => bp.response.id ?? -1)
                     }
                 }
             };
@@ -152,6 +152,6 @@ export class BreakpointTracker {
     }
 
     protected fireDataBreakpoints(): void {
-        this._onBreakpointsChanged.fire(this.breakpoints);
+        this._onBreakpointsChanged.fire(this.dataBreakpoints);
     }
 }

--- a/src/plugin/memory-webview-main.ts
+++ b/src/plugin/memory-webview-main.ts
@@ -356,8 +356,6 @@ export class MemoryWebview implements vscode.CustomReadonlyEditorProvider {
     }
 
     protected async onSetDataBreakpointCommand(ctx: WebviewContext, accessType: DebugProtocol.DataBreakpointAccessType): Promise<SetDataBreakpointsResult | undefined> {
-        console.log('Set Data Breakpoint', ctx);
-
         let dataId: string | undefined = undefined;
         if (isWebviewGroupContext(ctx)) {
             dataId = ctx.memoryData.group.startAddress;

--- a/src/plugin/session-tracker.ts
+++ b/src/plugin/session-tracker.ts
@@ -13,10 +13,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { DebugProtocol } from '@vscode/debugprotocol';
+import type { DebugProtocol } from '@vscode/debugprotocol';
 import * as vscode from 'vscode';
-import { isDebugEvent, isDebugRequest, isDebugResponse } from '../common/debug-requests';
-import { WrittenMemory } from '../common/memory-range';
+import { isDebugEvent, isDebugRequest, isDebugRequestType, isDebugResponse, isDebugResponseType } from '../common/debug-requests';
+import type { WrittenMemory } from '../common/memory-range';
+import type { ContinuedEvent, StoppedEvent } from '../common/messaging';
 
 export interface SessionInfo {
     raw: vscode.DebugSession;
@@ -24,6 +25,16 @@ export interface SessionInfo {
     clientCapabilities?: DebugProtocol.InitializeRequestArguments;
     active?: boolean;
     stopped?: boolean;
+}
+
+export interface SessionRequest {
+    session: SessionInfo;
+    request: DebugProtocol.Request
+}
+
+export interface SessionResponse {
+    session: SessionInfo;
+    response: DebugProtocol.Response
 }
 
 export interface SessionEvent {
@@ -45,11 +56,13 @@ export interface SessionMemoryWrittenEvent extends SessionEvent {
 export interface SessionStoppedEvent extends SessionEvent {
     event: 'stopped';
     session: SessionInfo;
+    data: StoppedEvent;
 }
 
 export interface SessionContinuedEvent extends SessionEvent {
     event: 'continued';
     session: SessionInfo;
+    data: ContinuedEvent
 }
 
 export interface SessionEvents {
@@ -74,9 +87,9 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
 
     private _onSessionEvent = new vscode.EventEmitter<SessionEvent>();
     public readonly onSessionEvent = this._onSessionEvent.event;
-    private _onSessionRequest = new vscode.EventEmitter<DebugProtocol.Request>();
+    private _onSessionRequest = new vscode.EventEmitter<SessionRequest>();
     public readonly onSessionRequest = this._onSessionRequest.event;
-    private _onSessionResponse = new vscode.EventEmitter<DebugProtocol.Response>();
+    private _onSessionResponse = new vscode.EventEmitter<SessionResponse>();
     public readonly onSessionResponse = this._onSessionResponse.event;
 
     activate(context: vscode.ExtensionContext): void {
@@ -115,6 +128,14 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
         this._onSessionEvent.fire({ event, session: this.sessionInfo(session), data });
     }
 
+    fireSessionRequest(session: vscode.DebugSession, data: DebugProtocol.Request): void {
+        this._onSessionRequest.fire({ session: this.sessionInfo(session), request: data });
+    }
+
+    fireSessionResponse(session: vscode.DebugSession, data: DebugProtocol.Response): void {
+        this._onSessionResponse.fire({ session: this.sessionInfo(session), response: data });
+    }
+
     protected async sessionWillStart(session: vscode.DebugSession): Promise<void> {
         this._sessionInfo.set(session.id, { raw: session });
     }
@@ -124,28 +145,34 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
     }
 
     protected willSendClientMessage(session: vscode.DebugSession, message: unknown): void {
-        console.log('[SEND] ==>', message);
+        // TODO: ONLY FOR DEMO PURPOSES
+        // console.log('[SEND] ==>', message);
         if (isDebugRequest('initialize', message)) {
             this.sessionInfo(session).clientCapabilities = message.arguments;
-        } else if (isDebugRequest('setDataBreakpoints', message)) {
-            this._onSessionRequest.fire(message);
+        }
+
+        if (isDebugRequestType(message)) {
+            this.fireSessionRequest(session, message);
         }
     }
 
     protected adapterMessageReceived(session: vscode.DebugSession, message: unknown): void {
-        console.log('[RECV] <==', message);
+        // TODO: ONLY FOR DEMO PURPOSES
+        // console.log('[RECV] <==', message);
         if (isDebugResponse('initialize', message)) {
             this.sessionInfo(session).debugCapabilities = message.body;
         } else if (isDebugEvent('stopped', message)) {
             this.sessionInfo(session).stopped = true;
-            this.fireSessionEvent(session, 'stopped', undefined);
+            this.fireSessionEvent(session, 'stopped', message);
         } else if (isDebugEvent('continued', message)) {
             this.sessionInfo(session).stopped = false;
-            this.fireSessionEvent(session, 'continued', undefined);
+            this.fireSessionEvent(session, 'continued', message);
         } else if (isDebugEvent('memory', message)) {
             this.fireSessionEvent(session, 'memory-written', message.body);
-        } else if (isDebugResponse('setDataBreakpoints', message)) {
-            this._onSessionResponse.fire(message);
+        }
+
+        if (isDebugResponseType(message)) {
+            this.fireSessionResponse(session, message);
         }
     }
 

--- a/src/plugin/session-tracker.ts
+++ b/src/plugin/session-tracker.ts
@@ -69,7 +69,7 @@ export interface SessionEvents {
     'active': ActiveSessionChangedEvent,
     'memory-written': SessionMemoryWrittenEvent,
     'continued': SessionContinuedEvent,
-    'stopped': SessionStoppedEvent,
+    'stopped': SessionStoppedEvent
 }
 
 export type DebugCapability = keyof DebugProtocol.Capabilities;
@@ -146,7 +146,7 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
 
     protected willSendClientMessage(session: vscode.DebugSession, message: unknown): void {
         // TODO: ONLY FOR DEMO PURPOSES
-        // console.log('[SEND] ==>', message);
+        console.log('[SEND] ==>', message);
         if (isDebugRequest('initialize', message)) {
             this.sessionInfo(session).clientCapabilities = message.arguments;
         }
@@ -158,7 +158,7 @@ export class SessionTracker implements vscode.DebugAdapterTrackerFactory {
 
     protected adapterMessageReceived(session: vscode.DebugSession, message: unknown): void {
         // TODO: ONLY FOR DEMO PURPOSES
-        // console.log('[RECV] <==', message);
+        console.log('[RECV] <==', message);
         if (isDebugResponse('initialize', message)) {
             this.sessionInfo(session).debugCapabilities = message.body;
         } else if (isDebugEvent('stopped', message)) {

--- a/src/webview/breakpoints/breakpoint-service.ts
+++ b/src/webview/breakpoints/breakpoint-service.ts
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { DataBreakpoints, TrackedBreakpointType } from '../../common/breakpoint';
+
+export interface BreakpointMetadata {
+    type?: TrackedBreakpointType,
+}
+
+export class BreakpointService {
+    protected dataBreakpoints: DataBreakpoints = { external: [], internal: [] };
+
+    update(dataBreakpoints: DataBreakpoints): void {
+        this.dataBreakpoints = dataBreakpoints;
+    }
+
+    isExternal(dataId: string): boolean {
+        return this.dataBreakpoints.external.some(bp => bp.dataId === dataId);
+    }
+
+    isInternal(dataId: string): boolean {
+        return this.dataBreakpoints.internal.some(bp => bp.dataId === dataId);
+    }
+
+    metadata(dataId: string): BreakpointMetadata | undefined {
+        if (this.isExternal(dataId)) {
+            return {
+                type: 'external'
+            };
+        } else if (this.isInternal(dataId)) {
+            return {
+                type: 'internal'
+            };
+        }
+
+        return undefined;
+    }
+}
+
+export namespace BreakpointService {
+    export namespace style {
+        export const dataBreakpoint = 'data-breakpoint';
+        export const dataBreakpointExternal = 'data-breakpoint-external';
+    }
+}
+
+export function breakpointClassNames(metadata?: BreakpointMetadata): string[] {
+    const classes: string[] = [];
+
+    if (metadata) {
+        if (metadata.type === 'external') {
+            classes.push(BreakpointService.style.dataBreakpoint, BreakpointService.style.dataBreakpointExternal);
+        } else if (metadata.type === 'internal') {
+            classes.push(BreakpointService.style.dataBreakpoint);
+        }
+    }
+
+    return classes;
+}
+
+export const breakpointService = new BreakpointService();

--- a/src/webview/breakpoints/breakpoint-service.ts
+++ b/src/webview/breakpoints/breakpoint-service.ts
@@ -50,7 +50,7 @@ export class BreakpointService implements UpdateExecutor {
         return this._stoppedEvent;
     }
 
-    init(): void {
+    activate(): void {
         messenger.onNotification(setTrackedBreakpointType, breakpoints => {
             this._breakpoints = breakpoints;
             this._onDidChange.fire();

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -21,8 +21,10 @@ import { ColumnContribution, ColumnFittingType, TableRenderOptions } from './col
 
 export class AddressColumn implements ColumnContribution {
     static ID = 'address';
+    static CLASS_NAME = 'column-address';
 
     readonly id = AddressColumn.ID;
+    readonly className = AddressColumn.CLASS_NAME;
     readonly label = 'Address';
     readonly priority = 0;
 

--- a/src/webview/columns/address-column.tsx
+++ b/src/webview/columns/address-column.tsx
@@ -14,9 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { classNames } from 'primereact/utils';
 import React, { ReactNode } from 'react';
 import { Memory } from '../../common/memory';
 import { BigIntMemoryRange, getAddressString, getRadixMarker } from '../../common/memory-range';
+import { BreakpointMetadata, BreakpointService, breakpointService } from '../breakpoints/breakpoint-service';
 import { ColumnContribution, ColumnFittingType, TableRenderOptions } from './column-contribution-service';
 
 export class AddressColumn implements ColumnContribution {
@@ -31,7 +33,13 @@ export class AddressColumn implements ColumnContribution {
     fittingType: ColumnFittingType = 'content-width';
 
     render(range: BigIntMemoryRange, _: Memory, options: TableRenderOptions): ReactNode {
+        const breakpointMetadata = breakpointService.inRange(range)
+            .map(bp => breakpointService.metadata(bp))
+            .filter((bp): bp is BreakpointMetadata => bp !== undefined);
+        const statusClasses = BreakpointService.statusClasses(breakpointMetadata);
+
         return <span className='memory-start-address hoverable' data-column='address'>
+            {statusClasses.length > 0 && <span className={classNames('address-status', statusClasses)}></span>}
             {options.showRadixPrefix && <span className='radix-prefix'>{getRadixMarker(options.addressRadix)}</span>}
             <span className='address'>{getAddressString(range.startAddress, options.addressRadix, options.effectiveAddressLength)}</span>
         </span>;

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -21,7 +21,7 @@ import { HOST_EXTENSION } from 'vscode-messenger-common';
 import { Memory } from '../../common/memory';
 import { BigIntMemoryRange, isWithin, toHexStringWithRadixMarker, toOffset } from '../../common/memory-range';
 import { writeMemoryType } from '../../common/messaging';
-import { breakpointClassNames, breakpointService } from '../breakpoints/breakpoint-service';
+import { BreakpointService, breakpointService } from '../breakpoints/breakpoint-service';
 import type { MemorySizeOptions } from '../components/memory-table';
 import { decorationService } from '../decorations/decoration-service';
 import { Disposable, FullNodeAttributes } from '../utils/view-types';
@@ -86,7 +86,7 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
     protected renderGroup(maus: React.ReactNode, startAddress: bigint, endAddress: bigint): React.ReactNode {
         const breakpointMetadata = breakpointService.metadata(toHexStringWithRadixMarker(startAddress));
         return <span
-            className={classNames('byte-group', 'hoverable', ...breakpointClassNames(breakpointMetadata))}
+            className={classNames('byte-group', 'hoverable', ...BreakpointService.inlineClasses(breakpointMetadata))}
             data-column='data'
             data-range={`${startAddress}-${endAddress}`}
             key={startAddress.toString(16)}

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -15,11 +15,13 @@
  ********************************************************************************/
 
 import { InputText } from 'primereact/inputtext';
+import { classNames } from 'primereact/utils';
 import * as React from 'react';
 import { HOST_EXTENSION } from 'vscode-messenger-common';
 import { Memory } from '../../common/memory';
 import { BigIntMemoryRange, isWithin, toHexStringWithRadixMarker, toOffset } from '../../common/memory-range';
 import { writeMemoryType } from '../../common/messaging';
+import { breakpointClassNames, breakpointService } from '../breakpoints/breakpoint-service';
 import type { MemorySizeOptions } from '../components/memory-table';
 import { decorationService } from '../decorations/decoration-service';
 import { Disposable, FullNodeAttributes } from '../utils/view-types';
@@ -82,13 +84,14 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
     }
 
     protected renderGroup(maus: React.ReactNode, startAddress: bigint, endAddress: bigint): React.ReactNode {
+        const breakpointMetadata = breakpointService.metadata(toHexStringWithRadixMarker(startAddress));
         return <span
-            className='byte-group hoverable'
+            className={classNames('byte-group', 'hoverable', ...breakpointClassNames(breakpointMetadata))}
             data-column='data'
             data-range={`${startAddress}-${endAddress}`}
             key={startAddress.toString(16)}
             onDoubleClick={this.setGroupEdit}
-            {...createGroupVscodeContext(startAddress, toOffset(startAddress, endAddress, this.props.options.bytesPerMau * 8))}
+            {...createGroupVscodeContext(startAddress, toOffset(startAddress, endAddress, this.props.options.bytesPerMau * 8), breakpointMetadata)}
         >
             {maus}
         </span>;

--- a/src/webview/columns/data-column.tsx
+++ b/src/webview/columns/data-column.tsx
@@ -23,6 +23,7 @@ import { writeMemoryType } from '../../common/messaging';
 import type { MemorySizeOptions } from '../components/memory-table';
 import { decorationService } from '../decorations/decoration-service';
 import { Disposable, FullNodeAttributes } from '../utils/view-types';
+import { createGroupVscodeContext } from '../utils/vscode-contexts';
 import { characterWidthInContainer, elementInnerWidth } from '../utils/window';
 import { messenger } from '../view-messenger';
 import { ColumnContribution, TableRenderOptions } from './column-contribution-service';
@@ -87,6 +88,7 @@ export class EditableDataColumnRow extends React.Component<EditableDataColumnRow
             data-range={`${startAddress}-${endAddress}`}
             key={startAddress.toString(16)}
             onDoubleClick={this.setGroupEdit}
+            {...createGroupVscodeContext(startAddress, toOffset(startAddress, endAddress, this.props.options.bytesPerMau * 8))}
         >
             {maus}
         </span>;

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -67,12 +67,15 @@ export class MemoryWidget extends React.Component<MemoryWidgetProps, MemoryWidge
 
     protected createVscodeContext(): VscodeContext {
         const visibleColumns = this.props.columns.filter(candidate => candidate.active).map(column => column.contribution.id);
+        const { messageParticipant, showRadixPrefix, endianness, bytesPerMau, activeReadArguments } = this.props;
         return createAppVscodeContext({
-            messageParticipant: this.props.messageParticipant,
-            showRadixPrefix: this.props.showRadixPrefix,
+            messageParticipant,
+            showRadixPrefix,
             showAsciiColumn: visibleColumns.includes('ascii'),
             showVariablesColumn: visibleColumns.includes('variables'),
-            activeReadArguments: this.props.activeReadArguments
+            endianness,
+            bytesPerMau,
+            activeReadArguments
         });
 
     }

--- a/src/webview/components/memory-widget.tsx
+++ b/src/webview/components/memory-widget.tsx
@@ -17,8 +17,7 @@
 import React from 'react';
 import { WebviewIdMessageParticipant } from 'vscode-messenger-common';
 import { Memory } from '../../common/memory';
-import { WebviewSelection } from '../../common/messaging';
-import { MemoryOptions, ReadMemoryArguments, SessionContext } from '../../common/messaging';
+import { MemoryOptions, ReadMemoryArguments, SessionContext, WebviewSelection } from '../../common/messaging';
 import { MemoryDisplayConfiguration } from '../../common/webview-configuration';
 import { ColumnStatus } from '../columns/column-contribution-service';
 import { HoverService } from '../hovers/hover-service';
@@ -39,9 +38,9 @@ interface MemoryWidgetProps extends MemoryDisplayConfiguration {
     columns: ColumnStatus[];
     effectiveAddressLength: number;
     isMemoryFetching: boolean;
+    isFrozen: boolean;
     updateMemoryState: (state: Partial<MemoryState>) => void;
     toggleColumn(id: string, active: boolean): void;
-    isFrozen: boolean;
     toggleFrozen: () => void;
     updateMemoryDisplayConfiguration: (memoryArguments: Partial<MemoryDisplayConfiguration>) => void;
     resetMemoryDisplayConfiguration: () => void;

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -14,87 +14,68 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import "primeflex/primeflex.css";
+import 'primeflex/primeflex.css';
 
-import { debounce } from "lodash";
-import { PrimeReactProvider } from "primereact/api";
-import React from "react";
-import { createRoot } from "react-dom/client";
+import { debounce } from 'lodash';
+import { PrimeReactProvider } from 'primereact/api';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { HOST_EXTENSION, WebviewIdMessageParticipant } from 'vscode-messenger-common';
+import * as manifest from '../common/manifest';
+import { createMemoryFromRead, Memory } from '../common/memory';
+import { BigIntMemoryRange, doOverlap, getAddressLength, getAddressString, WrittenMemory } from '../common/memory-range';
 import {
-  HOST_EXTENSION,
-  WebviewIdMessageParticipant,
-} from "vscode-messenger-common";
-import * as manifest from "../common/manifest";
-import { createMemoryFromRead, Memory } from "../common/memory";
-import {
-  BigIntMemoryRange,
-  doOverlap,
-  getAddressLength,
-  getAddressString,
-  WrittenMemory,
-} from "../common/memory-range";
-import {
-  applyMemoryType,
-  getWebviewSelectionType,
-  logMessageType,
-  MemoryOptions,
-  memoryWrittenType,
-  readMemoryType,
-  readyType,
-  resetMemoryViewSettingsType,
-  SessionContext,
-  sessionContextChangedType,
-  setMemoryViewSettingsType,
-  setOptionsType,
-  setTitleType,
-  showAdvancedOptionsType,
-  storeMemoryType,
-  WebviewSelection,
-} from "../common/messaging";
-import { Change, hasChanged, hasChangedTo } from "../common/typescript";
-import { MemoryDisplayConfiguration } from "../common/webview-configuration";
-import { breakpointService } from "./breakpoints/breakpoint-service";
-import { AddressColumn } from "./columns/address-column";
-import { AsciiColumn } from "./columns/ascii-column";
-import {
-  columnContributionService,
-  ColumnStatus,
-} from "./columns/column-contribution-service";
-import { DataColumn } from "./columns/data-column";
-import { MemoryWidget } from "./components/memory-widget";
-import { decorationService } from "./decorations/decoration-service";
-import { AddressHover } from "./hovers/address-hover";
-import { DataHover } from "./hovers/data-hover";
-import { HoverService, hoverService } from "./hovers/hover-service";
-import { VariableHover } from "./hovers/variable-hover";
-import {
-  Decoration,
-  DEFAULT_READ_ARGUMENTS,
-  MemoryState,
-} from "./utils/view-types";
-import { variableDecorator } from "./variables/variable-decorations";
-import { messenger } from "./view-messenger";
+    applyMemoryType,
+    getWebviewSelectionType,
+    logMessageType,
+    MemoryOptions,
+    memoryWrittenType,
+    readMemoryType,
+    readyType,
+    resetMemoryViewSettingsType,
+    SessionContext,
+    sessionContextChangedType,
+    setMemoryViewSettingsType,
+    setOptionsType,
+    setTitleType,
+    showAdvancedOptionsType,
+    storeMemoryType,
+    WebviewSelection,
+} from '../common/messaging';
+import { Change, hasChanged, hasChangedTo } from '../common/typescript';
+import { MemoryDisplayConfiguration } from '../common/webview-configuration';
+import { breakpointService } from './breakpoints/breakpoint-service';
+import { AddressColumn } from './columns/address-column';
+import { AsciiColumn } from './columns/ascii-column';
+import { columnContributionService, ColumnStatus } from './columns/column-contribution-service';
+import { DataColumn } from './columns/data-column';
+import { MemoryWidget } from './components/memory-widget';
+import { decorationService } from './decorations/decoration-service';
+import { AddressHover } from './hovers/address-hover';
+import { DataHover } from './hovers/data-hover';
+import { HoverService, hoverService } from './hovers/hover-service';
+import { VariableHover } from './hovers/variable-hover';
+import { Decoration, DEFAULT_READ_ARGUMENTS, MemoryState } from './utils/view-types';
+import { variableDecorator } from './variables/variable-decorations';
+import { messenger } from './view-messenger';
 
-export interface MemoryAppState
-  extends MemoryState,
-    MemoryDisplayConfiguration {
-  messageParticipant: WebviewIdMessageParticipant;
-  title: string;
-  sessionContext: SessionContext;
-  effectiveAddressLength: number;
-  decorations: Decoration[];
-  hoverService: HoverService;
-  columns: ColumnStatus[];
-  isFrozen: boolean;
+export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
+    messageParticipant: WebviewIdMessageParticipant;
+    title: string;
+    sessionContext: SessionContext;
+    effectiveAddressLength: number;
+    decorations: Decoration[];
+    hoverService: HoverService;
+    columns: ColumnStatus[];
+    isFrozen: boolean;
 }
 
 export const DEFAULT_SESSION_CONTEXT: SessionContext = {
-  canRead: false,
-  canWrite: false,
+    canRead: false,
+    canWrite: false
 };
 
-export const DEFAULT_MEMORY_DISPLAY_CONFIGURATION: MemoryDisplayConfiguration =
-  {
+export const DEFAULT_MEMORY_DISPLAY_CONFIGURATION: MemoryDisplayConfiguration = {
     bytesPerMau: manifest.DEFAULT_BYTES_PER_MAU,
     mausPerGroup: manifest.DEFAULT_MAUS_PER_GROUP,
     groupsPerRow: manifest.DEFAULT_GROUPS_PER_ROW,
@@ -105,380 +86,280 @@ export const DEFAULT_MEMORY_DISPLAY_CONFIGURATION: MemoryDisplayConfiguration =
     showRadixPrefix: manifest.DEFAULT_SHOW_RADIX_PREFIX,
     refreshOnStop: manifest.DEFAULT_REFRESH_ON_STOP,
     periodicRefresh: manifest.DEFAULT_PERIODIC_REFRESH,
-    periodicRefreshInterval: manifest.DEFAULT_PERIODIC_REFRESH_INTERVAL,
-  };
+    periodicRefreshInterval: manifest.DEFAULT_PERIODIC_REFRESH_INTERVAL
+};
 
 class App extends React.Component<{}, MemoryAppState> {
-  protected memoryWidget = React.createRef<MemoryWidget>();
-  protected refreshTimer?: NodeJS.Timeout | number;
+    protected memoryWidget = React.createRef<MemoryWidget>();
+    protected refreshTimer?: NodeJS.Timeout | number;
 
-  public constructor(props: {}) {
-    super(props);
-    columnContributionService.register(new AddressColumn(), false);
-    columnContributionService.register(new DataColumn(), false);
-    columnContributionService.register(variableDecorator);
-    columnContributionService.register(new AsciiColumn());
-    decorationService.register(variableDecorator);
-    hoverService.register(new AddressHover());
-    hoverService.register(new DataHover());
-    hoverService.register(new VariableHover());
-    this.state = {
-      messageParticipant: { type: "webview", webviewId: "" },
-      title: "Memory",
-      sessionContext: DEFAULT_SESSION_CONTEXT,
-      memory: undefined,
-      effectiveAddressLength: 0,
-      configuredReadArguments: DEFAULT_READ_ARGUMENTS,
-      activeReadArguments: DEFAULT_READ_ARGUMENTS,
-      decorations: [],
-      hoverService: hoverService,
-      columns: columnContributionService.getColumns(),
-      isMemoryFetching: false,
-      isFrozen: false,
-      ...DEFAULT_MEMORY_DISPLAY_CONFIGURATION,
-    };
-  }
+    public constructor(props: {}) {
+        super(props);
+        columnContributionService.register(new AddressColumn(), false);
+        columnContributionService.register(new DataColumn(), false);
+        columnContributionService.register(variableDecorator);
+        columnContributionService.register(new AsciiColumn());
+        decorationService.register(variableDecorator);
+        hoverService.register(new AddressHover());
+        hoverService.register(new DataHover());
+        hoverService.register(new VariableHover());
+        this.state = {
+            messageParticipant: { type: 'webview', webviewId: '' },
+            title: 'Memory',
+            sessionContext: DEFAULT_SESSION_CONTEXT,
+            memory: undefined,
+            effectiveAddressLength: 0,
+            configuredReadArguments: DEFAULT_READ_ARGUMENTS,
+            activeReadArguments: DEFAULT_READ_ARGUMENTS,
+            decorations: [],
+            hoverService: hoverService,
+            columns: columnContributionService.getColumns(),
+            isMemoryFetching: false,
+            isFrozen: false,
+            ...DEFAULT_MEMORY_DISPLAY_CONFIGURATION
+        };
+    }
 
-  public componentDidMount(): void {
-    messenger.onRequest(setOptionsType, (options) => this.setOptions(options));
-    messenger.onNotification(memoryWrittenType, (writtenMemory) =>
-      this.memoryWritten(writtenMemory)
-    );
-    messenger.onNotification(sessionContextChangedType, (sessionContext) =>
-      this.sessionContextChanged(sessionContext)
-    );
-    messenger.onNotification(setMemoryViewSettingsType, (config) => {
-      if (config.visibleColumns) {
-        for (const column of columnContributionService.getColumns()) {
-          const id = column.contribution.id;
-          const configurable = column.configurable;
-          this.toggleColumn(
-            id,
-            !configurable || config.visibleColumns.includes(id)
-          );
+    public componentDidMount(): void {
+        messenger.onRequest(setOptionsType, options => this.setOptions(options));
+        messenger.onNotification(memoryWrittenType, writtenMemory => this.memoryWritten(writtenMemory));
+        messenger.onNotification(sessionContextChangedType, sessionContext => this.sessionContextChanged(sessionContext));
+        messenger.onNotification(setMemoryViewSettingsType, config => {
+            if (config.visibleColumns) {
+                for (const column of columnContributionService.getColumns()) {
+                    const id = column.contribution.id;
+                    const configurable = column.configurable;
+                    this.toggleColumn(id, !configurable || config.visibleColumns.includes(id));
+                }
+            }
+            this.setState(prevState => ({ ...prevState, ...config, title: config.title ?? prevState.title, }));
+        });
+        messenger.onRequest(getWebviewSelectionType, () => this.getWebviewSelection());
+        messenger.onNotification(showAdvancedOptionsType, () => this.showAdvancedOptions());
+        messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
+        breakpointService.activate();
+        breakpointService.onDidChange(() => this.forceUpdate());
+        this.updatePeriodicRefresh();
+    }
+
+    public componentDidUpdate(_: {}, from: MemoryAppState): void {
+        const current = this.state;
+        const stateChange: Change<MemoryAppState> = { from, to: current };
+        const sessionContextChange: Change<SessionContext> = { from: from.sessionContext, to: current.sessionContext };
+
+        if (hasChanged(stateChange, 'addressPadding') || (this.state.addressPadding === 'Minimal' && hasChanged(stateChange, 'memory'))) {
+            const effectiveAddressLength = this.getEffectiveAddressLength(this.state.memory);
+            if (this.state.effectiveAddressLength !== effectiveAddressLength) {
+                this.setState({ effectiveAddressLength });
+            }
         }
-      }
-      this.setState((prevState) => ({
-        ...prevState,
-        ...config,
-        title: config.title ?? prevState.title,
-      }));
-    });
-    messenger.onRequest(getWebviewSelectionType, () =>
-      this.getWebviewSelection()
-    );
-    messenger.onNotification(showAdvancedOptionsType, () =>
-      this.showAdvancedOptions()
-    );
-    messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
-    breakpointService.activate();
-    breakpointService.onDidChange(() => this.forceUpdate());
-    this.updatePeriodicRefresh();
-  }
+        if (hasChanged(stateChange, 'periodicRefresh') || hasChanged(stateChange, 'periodicRefreshInterval') || hasChanged(sessionContextChange, 'stopped')) {
+            this.updatePeriodicRefresh();
+        }
 
-  public componentDidUpdate(_: {}, from: MemoryAppState): void {
-    const current = this.state;
-    const stateChange: Change<MemoryAppState> = { from, to: current };
-    const sessionContextChange: Change<SessionContext> = {
-      from: from.sessionContext,
-      to: current.sessionContext,
+        if (current.refreshOnStop === 'on' && hasChangedTo(sessionContextChange, 'stopped', true)) {
+            this.fetchMemory();
+        }
+
+        hoverService.setMemoryState(this.state);
+    }
+
+    componentWillUnmount(): void {
+        clearTimeout(this.refreshTimer);
+    }
+
+    protected updatePeriodicRefresh = (): void => {
+        clearTimeout(this.refreshTimer);
+
+        if (this.state.periodicRefreshInterval && this.state.periodicRefreshInterval > 0 &&
+            this.state.periodicRefresh === 'always' || (this.state.periodicRefresh === 'while running' && !this.state.sessionContext.stopped)) {
+            // we do not use an interval here as we only want to schedule another refresh AFTER the previous execution AND the delay has passed
+            // and not strictly every n milliseconds. Even if 'fetchMemory' fails here, we schedule another auto-refresh.
+            const scheduleRefresh = () => this.fetchMemory().finally(() => this.updatePeriodicRefresh());
+            this.refreshTimer = setTimeout(scheduleRefresh, this.state.periodicRefreshInterval);
+        }
     };
 
-    if (
-      hasChanged(stateChange, "addressPadding") ||
-      (this.state.addressPadding === "Minimal" &&
-        hasChanged(stateChange, "memory"))
-    ) {
-      const effectiveAddressLength = this.getEffectiveAddressLength(
-        this.state.memory
-      );
-      if (this.state.effectiveAddressLength !== effectiveAddressLength) {
-        this.setState({ effectiveAddressLength });
-      }
-    }
-    if (
-      hasChanged(stateChange, "periodicRefresh") ||
-      hasChanged(stateChange, "periodicRefreshInterval") ||
-      hasChanged(sessionContextChange, "stopped")
-    ) {
-      this.updatePeriodicRefresh();
-    }
+    // use a slight debounce as the same event may come in short succession
+    protected memoryWritten = debounce((writtenMemory: WrittenMemory): void => {
+        if (!this.state.memory) {
+            return;
+        }
+        if (this.state.activeReadArguments.memoryReference === writtenMemory.memoryReference) {
+            // catch simple case
+            this.fetchMemory();
+            return;
+        }
+        try {
+            // If we are dealing with numeric addresses (and not expressions) then we can determine the overlap.
+            // Note that we use big int arithmetic here to determine the overlap for (start address + length) vs (memory state address + length), i.e.,
+            // we do not actually determine the end address may need to consider the size of a MAU in bytes
+            const written: BigIntMemoryRange = {
+                startAddress: BigInt(writtenMemory.memoryReference),
+                endAddress: BigInt(writtenMemory.memoryReference) + BigInt(writtenMemory.count ?? 0)
+            };
+            const shown: BigIntMemoryRange = {
+                startAddress: this.state.memory.address,
+                endAddress: this.state.memory.address + BigInt(this.state.memory.bytes.length)
+            };
+            if (doOverlap(written, shown)) {
+                this.fetchMemory();
+                return;
+            }
+        } catch (error) {
+            // ignore and fall through
+        }
 
-    if (
-      current.refreshOnStop === "on" &&
-      hasChangedTo(sessionContextChange, "stopped", true)
-    ) {
-      this.fetchMemory();
-    }
-
-    hoverService.setMemoryState(this.state);
-  }
-
-  componentWillUnmount(): void {
-    clearTimeout(this.refreshTimer);
-  }
-
-  protected updatePeriodicRefresh = (): void => {
-    clearTimeout(this.refreshTimer);
-
-    if (
-      (this.state.periodicRefreshInterval &&
-        this.state.periodicRefreshInterval > 0 &&
-        this.state.periodicRefresh === "always") ||
-      (this.state.periodicRefresh === "while running" &&
-        !this.state.sessionContext.stopped)
-    ) {
-      // we do not use an interval here as we only want to schedule another refresh AFTER the previous execution AND the delay has passed
-      // and not strictly every n milliseconds. Even if 'fetchMemory' fails here, we schedule another auto-refresh.
-      const scheduleRefresh = () =>
-        this.fetchMemory().finally(() => this.updatePeriodicRefresh());
-      this.refreshTimer = setTimeout(
-        scheduleRefresh,
-        this.state.periodicRefreshInterval
-      );
-    }
-  };
-
-  // use a slight debounce as the same event may come in short succession
-  protected memoryWritten = debounce((writtenMemory: WrittenMemory): void => {
-    if (!this.state.memory) {
-      return;
-    }
-    if (
-      this.state.activeReadArguments.memoryReference ===
-      writtenMemory.memoryReference
-    ) {
-      // catch simple case
-      this.fetchMemory();
-      return;
-    }
-    try {
-      // If we are dealing with numeric addresses (and not expressions) then we can determine the overlap.
-      // Note that we use big int arithmetic here to determine the overlap for (start address + length) vs (memory state address + length), i.e.,
-      // we do not actually determine the end address may need to consider the size of a MAU in bytes
-      const written: BigIntMemoryRange = {
-        startAddress: BigInt(writtenMemory.memoryReference),
-        endAddress:
-          BigInt(writtenMemory.memoryReference) +
-          BigInt(writtenMemory.count ?? 0),
-      };
-      const shown: BigIntMemoryRange = {
-        startAddress: this.state.memory.address,
-        endAddress:
-          this.state.memory.address + BigInt(this.state.memory.bytes.length),
-      };
-      if (doOverlap(written, shown)) {
+        // we could try to convert any expression we may have to an address by sending an evaluation request to the DA
+        // but for now we just go with a pessimistic approach: if we are unsure, we refresh the memory
         this.fetchMemory();
-        return;
-      }
-    } catch (error) {
-      // ignore and fall through
+    }, 100);
+
+    protected sessionContextChanged(sessionContext: SessionContext): void {
+        this.setState({ sessionContext });
     }
 
-    // we could try to convert any expression we may have to an address by sending an evaluation request to the DA
-    // but for now we just go with a pessimistic approach: if we are unsure, we refresh the memory
-    this.fetchMemory();
-  }, 100);
-
-  protected sessionContextChanged(sessionContext: SessionContext): void {
-    this.setState({ sessionContext });
-  }
-
-  public render(): React.ReactNode {
-    return (
-      <PrimeReactProvider>
-        <MemoryWidget
-          ref={this.memoryWidget}
-          messageParticipant={this.state.messageParticipant}
-          sessionContext={this.state.sessionContext}
-          configuredReadArguments={this.state.configuredReadArguments}
-          activeReadArguments={this.state.activeReadArguments}
-          memory={this.state.memory}
-          decorations={this.state.decorations}
-          hoverService={this.state.hoverService}
-          columns={this.state.columns}
-          title={this.state.title}
-          effectiveAddressLength={this.state.effectiveAddressLength}
-          updateMemoryState={this.updateMemoryState}
-          updateMemoryDisplayConfiguration={
-            this.updateMemoryDisplayConfiguration
-          }
-          resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
-          updateTitle={this.updateTitle}
-          toggleColumn={this.toggleColumn}
-          toggleFrozen={this.toggleFrozen}
-          isFrozen={this.state.isFrozen}
-          fetchMemory={this.fetchMemory}
-          isMemoryFetching={this.state.isMemoryFetching}
-          bytesPerMau={this.state.bytesPerMau}
-          groupsPerRow={this.state.groupsPerRow}
-          endianness={this.state.endianness}
-          mausPerGroup={this.state.mausPerGroup}
-          scrollingBehavior={this.state.scrollingBehavior}
-          addressPadding={this.state.addressPadding}
-          addressRadix={this.state.addressRadix}
-          showRadixPrefix={this.state.showRadixPrefix}
-          storeMemory={this.storeMemory}
-          applyMemory={this.applyMemory}
-          refreshOnStop={this.state.refreshOnStop}
-          periodicRefresh={this.state.periodicRefresh}
-          periodicRefreshInterval={this.state.periodicRefreshInterval}
-        />
-      </PrimeReactProvider>
-    );
-  }
-
-  protected updateMemoryState = (newState?: Partial<MemoryState>) =>
-    this.setState((prevState) => ({ ...prevState, ...newState }));
-  protected updateMemoryDisplayConfiguration = (
-    newState: Partial<MemoryDisplayConfiguration>
-  ) => this.setState((prevState) => ({ ...prevState, ...newState }));
-  protected resetMemoryDisplayConfiguration = () =>
-    messenger.sendNotification(
-      resetMemoryViewSettingsType,
-      HOST_EXTENSION,
-      undefined
-    );
-
-  protected updateTitle = (title: string) => {
-    this.setState({ title });
-    messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
-  };
-
-  protected async setOptions(options?: MemoryOptions): Promise<void> {
-    messenger.sendRequest(
-      logMessageType,
-      HOST_EXTENSION,
-      `Setting options: ${JSON.stringify(options)}`
-    );
-    this.setState({
-      configuredReadArguments: {
-        ...this.state.configuredReadArguments,
-        ...options,
-      },
-    });
-    return this.fetchMemory(options);
-  }
-
-  protected fetchMemory = async (
-    partialOptions?: MemoryOptions
-  ): Promise<void> => {
-    if (this.state.isFrozen || !this.state.sessionContext.canRead) {
-      return;
+    public render(): React.ReactNode {
+        return <PrimeReactProvider>
+            <MemoryWidget
+                ref={this.memoryWidget}
+                messageParticipant={this.state.messageParticipant}
+                sessionContext={this.state.sessionContext}
+                configuredReadArguments={this.state.configuredReadArguments}
+                activeReadArguments={this.state.activeReadArguments}
+                memory={this.state.memory}
+                decorations={this.state.decorations}
+                hoverService={this.state.hoverService}
+                columns={this.state.columns}
+                title={this.state.title}
+                effectiveAddressLength={this.state.effectiveAddressLength}
+                updateMemoryState={this.updateMemoryState}
+                updateMemoryDisplayConfiguration={this.updateMemoryDisplayConfiguration}
+                resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
+                updateTitle={this.updateTitle}
+                toggleColumn={this.toggleColumn}
+                toggleFrozen={this.toggleFrozen}
+                isFrozen={this.state.isFrozen}
+                fetchMemory={this.fetchMemory}
+                isMemoryFetching={this.state.isMemoryFetching}
+                bytesPerMau={this.state.bytesPerMau}
+                groupsPerRow={this.state.groupsPerRow}
+                endianness={this.state.endianness}
+                mausPerGroup={this.state.mausPerGroup}
+                scrollingBehavior={this.state.scrollingBehavior}
+                addressPadding={this.state.addressPadding}
+                addressRadix={this.state.addressRadix}
+                showRadixPrefix={this.state.showRadixPrefix}
+                storeMemory={this.storeMemory}
+                applyMemory={this.applyMemory}
+                refreshOnStop={this.state.refreshOnStop}
+                periodicRefresh={this.state.periodicRefresh}
+                periodicRefreshInterval={this.state.periodicRefreshInterval}
+            />
+        </PrimeReactProvider>;
     }
-    const completeOptions = {
-      memoryReference:
-        partialOptions?.memoryReference ||
-        this.state.activeReadArguments.memoryReference,
-      offset: partialOptions?.offset ?? this.state.activeReadArguments.offset,
-      count: partialOptions?.count ?? this.state.activeReadArguments.count,
+
+    protected updateMemoryState = (newState?: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
+    protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryViewSettingsType, HOST_EXTENSION, undefined);
+
+    protected updateTitle = (title: string) => {
+        this.setState({ title });
+        messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
     };
-    // Don't fetch memory if we have an incomplete memory reference
-    if (completeOptions.memoryReference === "") {
-      return;
+
+    protected async setOptions(options?: MemoryOptions): Promise<void> {
+        messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);
+        this.setState({ configuredReadArguments: { ...this.state.configuredReadArguments, ...options } });
+        return this.fetchMemory(options);
     }
-    return this.doFetchMemory(completeOptions);
-  };
 
-  protected async doFetchMemory(
-    memoryOptions: Required<MemoryOptions>
-  ): Promise<void> {
-    this.setState({
-      isMemoryFetching: true,
-      activeReadArguments: memoryOptions,
-    });
+    protected fetchMemory = async (partialOptions?: MemoryOptions): Promise<void> => {
+        if (this.state.isFrozen || !this.state.sessionContext.canRead) {
+            return;
+        }
+        const completeOptions = {
+            memoryReference: partialOptions?.memoryReference || this.state.activeReadArguments.memoryReference,
+            offset: partialOptions?.offset ?? this.state.activeReadArguments.offset,
+            count: partialOptions?.count ?? this.state.activeReadArguments.count
+        };
+        // Don't fetch memory if we have an incomplete memory reference
+        if (completeOptions.memoryReference === '') {
+            return;
+        }
+        return this.doFetchMemory(completeOptions);
+    };
 
-    try {
-      const response = await messenger.sendRequest(
-        readMemoryType,
-        HOST_EXTENSION,
-        memoryOptions
-      );
-      await Promise.all(
-        Array.from(
-          new Set(
-            columnContributionService
-              .getUpdateExecutors()
-              .concat(decorationService.getUpdateExecutors())
-              .concat(breakpointService)
-          ),
-          (executor) => executor.fetchData(memoryOptions)
-        )
-      );
+    protected async doFetchMemory(memoryOptions: Required<MemoryOptions>): Promise<void> {
+        this.setState({ isMemoryFetching: true, activeReadArguments: memoryOptions });
 
-      const memory = createMemoryFromRead(response);
-      this.setState({ memory, decorations: decorationService.decorations });
-      messenger.sendRequest(setOptionsType, HOST_EXTENSION, memoryOptions);
-    } catch (ex) {
-      // Do not show old results if the current search provided no memory
-      this.setState({ memory: undefined });
+        try {
+            const response = await messenger.sendRequest(readMemoryType, HOST_EXTENSION, memoryOptions);
+            await Promise.all(Array.from(
+                new Set(columnContributionService
+                    .getUpdateExecutors()
+                    .concat(decorationService.getUpdateExecutors())
+                    .concat(breakpointService)),
+                executor => executor.fetchData(memoryOptions)
+            ));
 
-      if (ex instanceof Error) {
-        console.error(ex);
-      }
-    } finally {
-      this.setState({ isMemoryFetching: false });
+            const memory = createMemoryFromRead(response);
+            this.setState({ memory, decorations: decorationService.decorations });
+            messenger.sendRequest(setOptionsType, HOST_EXTENSION, memoryOptions);
+        } catch (ex) {
+            // Do not show old results if the current search provided no memory
+            this.setState({ memory: undefined });
+
+            if (ex instanceof Error) {
+                console.error(ex);
+            }
+        } finally {
+            this.setState({ isMemoryFetching: false });
+        }
     }
-  }
 
-  protected getEffectiveAddressLength(memory?: Memory): number {
-    const { addressRadix, addressPadding } = this.state;
-    return addressPadding === "Minimal"
-      ? this.getLastAddressLength(memory)
-      : getAddressLength(addressPadding, addressRadix);
-  }
-
-  protected getLastAddressLength(memory?: Memory): number {
-    if (memory === undefined || this.state.groupsPerRow === "Autofit") {
-      return 0;
+    protected getEffectiveAddressLength(memory?: Memory): number {
+        const { addressRadix, addressPadding } = this.state;
+        return addressPadding === 'Minimal' ? this.getLastAddressLength(memory) : getAddressLength(addressPadding, addressRadix);
     }
-    const rowLength =
-      this.state.bytesPerMau *
-      this.state.mausPerGroup *
-      this.state.groupsPerRow;
-    const rows = Math.ceil(memory.bytes.length / rowLength);
-    const finalAddress = memory.address + BigInt((rows - 1) * rowLength);
-    return getAddressString(finalAddress, this.state.addressRadix).length;
-  }
 
-  protected toggleColumn = (id: string, active: boolean): void => {
-    this.doToggleColumn(id, active);
-  };
-  protected async doToggleColumn(
-    id: string,
-    isVisible: boolean
-  ): Promise<void> {
-    const columns = isVisible
-      ? await columnContributionService.show(id, this.state)
-      : columnContributionService.hide(id);
-    this.setState({ columns });
-  }
+    protected getLastAddressLength(memory?: Memory): number {
+        if (memory === undefined || this.state.groupsPerRow === 'Autofit') {
+            return 0;
+        }
+        const rowLength = this.state.bytesPerMau * this.state.mausPerGroup * this.state.groupsPerRow;
+        const rows = Math.ceil(memory.bytes.length / rowLength);
+        const finalAddress = memory.address + BigInt(((rows - 1) * rowLength));
+        return getAddressString(finalAddress, this.state.addressRadix).length;
+    }
 
-  protected toggleFrozen = (): void => {
-    this.doToggleFrozen();
-  };
-  protected doToggleFrozen(): void {
-    this.setState((prevState) => ({ isFrozen: !prevState.isFrozen }));
-  }
+    protected toggleColumn = (id: string, active: boolean): void => { this.doToggleColumn(id, active); };
+    protected async doToggleColumn(id: string, isVisible: boolean): Promise<void> {
+        const columns = isVisible ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
+        this.setState({ columns });
+    }
 
-  protected showAdvancedOptions(): void {
-    this.memoryWidget.current?.showAdvancedOptions();
-  }
+    protected toggleFrozen = (): void => { this.doToggleFrozen(); };
+    protected doToggleFrozen(): void {
+        this.setState(prevState => ({ isFrozen: !prevState.isFrozen }));
+    }
 
-  protected getWebviewSelection(): WebviewSelection {
-    return this.memoryWidget.current?.getWebviewSelection() ?? {};
-  }
+    protected showAdvancedOptions(): void {
+        this.memoryWidget.current?.showAdvancedOptions();
+    }
 
-  protected storeMemory = async (): Promise<void> => {
-    await messenger.sendRequest(storeMemoryType, HOST_EXTENSION, {
-      ...this.state.activeReadArguments,
-    });
-  };
+    protected getWebviewSelection(): WebviewSelection {
+        return this.memoryWidget.current?.getWebviewSelection() ?? {};
+    }
 
-  protected applyMemory = async (): Promise<void> => {
-    await messenger.sendRequest(applyMemoryType, HOST_EXTENSION, undefined);
-  };
+    protected storeMemory = async (): Promise<void> => {
+        await messenger.sendRequest(storeMemoryType, HOST_EXTENSION, { ...this.state.activeReadArguments });
+    };
+
+    protected applyMemory = async (): Promise<void> => {
+        await messenger.sendRequest(applyMemoryType, HOST_EXTENSION, undefined);
+    };
 }
 
-const container = document.getElementById("root") as Element;
+const container = document.getElementById('root') as Element;
 createRoot(container).render(<App />);

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -14,68 +14,87 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import 'primeflex/primeflex.css';
+import "primeflex/primeflex.css";
 
-import { debounce } from 'lodash';
-import { PrimeReactProvider } from 'primereact/api';
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import { HOST_EXTENSION, WebviewIdMessageParticipant } from 'vscode-messenger-common';
-import * as manifest from '../common/manifest';
-import { createMemoryFromRead, Memory } from '../common/memory';
-import { BigIntMemoryRange, doOverlap, getAddressLength, getAddressString, WrittenMemory } from '../common/memory-range';
+import { debounce } from "lodash";
+import { PrimeReactProvider } from "primereact/api";
+import React from "react";
+import { createRoot } from "react-dom/client";
 import {
-    applyMemoryType,
-    getWebviewSelectionType,
-    logMessageType,
-    MemoryOptions,
-    memoryWrittenType,
-    readMemoryType,
-    readyType,
-    resetMemoryViewSettingsType,
-    SessionContext,
-    sessionContextChangedType,
-    setMemoryViewSettingsType,
-    setOptionsType,
-    setTitleType,
-    showAdvancedOptionsType,
-    storeMemoryType,
-    WebviewSelection,
-} from '../common/messaging';
-import { Change, hasChanged, hasChangedTo } from '../common/typescript';
-import { MemoryDisplayConfiguration } from '../common/webview-configuration';
-import { breakpointService } from './breakpoints/breakpoint-service';
-import { AddressColumn } from './columns/address-column';
-import { AsciiColumn } from './columns/ascii-column';
-import { columnContributionService, ColumnStatus } from './columns/column-contribution-service';
-import { DataColumn } from './columns/data-column';
-import { MemoryWidget } from './components/memory-widget';
-import { decorationService } from './decorations/decoration-service';
-import { AddressHover } from './hovers/address-hover';
-import { DataHover } from './hovers/data-hover';
-import { HoverService, hoverService } from './hovers/hover-service';
-import { VariableHover } from './hovers/variable-hover';
-import { Decoration, DEFAULT_READ_ARGUMENTS, MemoryState } from './utils/view-types';
-import { variableDecorator } from './variables/variable-decorations';
-import { messenger } from './view-messenger';
+  HOST_EXTENSION,
+  WebviewIdMessageParticipant,
+} from "vscode-messenger-common";
+import * as manifest from "../common/manifest";
+import { createMemoryFromRead, Memory } from "../common/memory";
+import {
+  BigIntMemoryRange,
+  doOverlap,
+  getAddressLength,
+  getAddressString,
+  WrittenMemory,
+} from "../common/memory-range";
+import {
+  applyMemoryType,
+  getWebviewSelectionType,
+  logMessageType,
+  MemoryOptions,
+  memoryWrittenType,
+  readMemoryType,
+  readyType,
+  resetMemoryViewSettingsType,
+  SessionContext,
+  sessionContextChangedType,
+  setMemoryViewSettingsType,
+  setOptionsType,
+  setTitleType,
+  showAdvancedOptionsType,
+  storeMemoryType,
+  WebviewSelection,
+} from "../common/messaging";
+import { Change, hasChanged, hasChangedTo } from "../common/typescript";
+import { MemoryDisplayConfiguration } from "../common/webview-configuration";
+import { breakpointService } from "./breakpoints/breakpoint-service";
+import { AddressColumn } from "./columns/address-column";
+import { AsciiColumn } from "./columns/ascii-column";
+import {
+  columnContributionService,
+  ColumnStatus,
+} from "./columns/column-contribution-service";
+import { DataColumn } from "./columns/data-column";
+import { MemoryWidget } from "./components/memory-widget";
+import { decorationService } from "./decorations/decoration-service";
+import { AddressHover } from "./hovers/address-hover";
+import { DataHover } from "./hovers/data-hover";
+import { HoverService, hoverService } from "./hovers/hover-service";
+import { VariableHover } from "./hovers/variable-hover";
+import {
+  Decoration,
+  DEFAULT_READ_ARGUMENTS,
+  MemoryState,
+} from "./utils/view-types";
+import { variableDecorator } from "./variables/variable-decorations";
+import { messenger } from "./view-messenger";
 
-export interface MemoryAppState extends MemoryState, MemoryDisplayConfiguration {
-    messageParticipant: WebviewIdMessageParticipant;
-    title: string;
-    sessionContext: SessionContext;
-    effectiveAddressLength: number;
-    decorations: Decoration[];
-    hoverService: HoverService;
-    columns: ColumnStatus[];
-    isFrozen: boolean;
+export interface MemoryAppState
+  extends MemoryState,
+    MemoryDisplayConfiguration {
+  messageParticipant: WebviewIdMessageParticipant;
+  title: string;
+  sessionContext: SessionContext;
+  effectiveAddressLength: number;
+  decorations: Decoration[];
+  hoverService: HoverService;
+  columns: ColumnStatus[];
+  isFrozen: boolean;
 }
 
 export const DEFAULT_SESSION_CONTEXT: SessionContext = {
-    canRead: false,
-    canWrite: false
+  canRead: false,
+  canWrite: false,
 };
 
-export const DEFAULT_MEMORY_DISPLAY_CONFIGURATION: MemoryDisplayConfiguration = {
+export const DEFAULT_MEMORY_DISPLAY_CONFIGURATION: MemoryDisplayConfiguration =
+  {
     bytesPerMau: manifest.DEFAULT_BYTES_PER_MAU,
     mausPerGroup: manifest.DEFAULT_MAUS_PER_GROUP,
     groupsPerRow: manifest.DEFAULT_GROUPS_PER_ROW,
@@ -86,280 +105,380 @@ export const DEFAULT_MEMORY_DISPLAY_CONFIGURATION: MemoryDisplayConfiguration = 
     showRadixPrefix: manifest.DEFAULT_SHOW_RADIX_PREFIX,
     refreshOnStop: manifest.DEFAULT_REFRESH_ON_STOP,
     periodicRefresh: manifest.DEFAULT_PERIODIC_REFRESH,
-    periodicRefreshInterval: manifest.DEFAULT_PERIODIC_REFRESH_INTERVAL
-};
+    periodicRefreshInterval: manifest.DEFAULT_PERIODIC_REFRESH_INTERVAL,
+  };
 
 class App extends React.Component<{}, MemoryAppState> {
-    protected memoryWidget = React.createRef<MemoryWidget>();
-    protected refreshTimer?: NodeJS.Timeout | number;
+  protected memoryWidget = React.createRef<MemoryWidget>();
+  protected refreshTimer?: NodeJS.Timeout | number;
 
-    public constructor(props: {}) {
-        super(props);
-        columnContributionService.register(new AddressColumn(), false);
-        columnContributionService.register(new DataColumn(), false);
-        columnContributionService.register(variableDecorator);
-        columnContributionService.register(new AsciiColumn());
-        decorationService.register(variableDecorator);
-        hoverService.register(new AddressHover());
-        hoverService.register(new DataHover());
-        hoverService.register(new VariableHover());
-        this.state = {
-            messageParticipant: { type: 'webview', webviewId: '' },
-            title: 'Memory',
-            sessionContext: DEFAULT_SESSION_CONTEXT,
-            memory: undefined,
-            effectiveAddressLength: 0,
-            configuredReadArguments: DEFAULT_READ_ARGUMENTS,
-            activeReadArguments: DEFAULT_READ_ARGUMENTS,
-            decorations: [],
-            hoverService: hoverService,
-            columns: columnContributionService.getColumns(),
-            isMemoryFetching: false,
-            isFrozen: false,
-            ...DEFAULT_MEMORY_DISPLAY_CONFIGURATION
-        };
-    }
+  public constructor(props: {}) {
+    super(props);
+    columnContributionService.register(new AddressColumn(), false);
+    columnContributionService.register(new DataColumn(), false);
+    columnContributionService.register(variableDecorator);
+    columnContributionService.register(new AsciiColumn());
+    decorationService.register(variableDecorator);
+    hoverService.register(new AddressHover());
+    hoverService.register(new DataHover());
+    hoverService.register(new VariableHover());
+    this.state = {
+      messageParticipant: { type: "webview", webviewId: "" },
+      title: "Memory",
+      sessionContext: DEFAULT_SESSION_CONTEXT,
+      memory: undefined,
+      effectiveAddressLength: 0,
+      configuredReadArguments: DEFAULT_READ_ARGUMENTS,
+      activeReadArguments: DEFAULT_READ_ARGUMENTS,
+      decorations: [],
+      hoverService: hoverService,
+      columns: columnContributionService.getColumns(),
+      isMemoryFetching: false,
+      isFrozen: false,
+      ...DEFAULT_MEMORY_DISPLAY_CONFIGURATION,
+    };
+  }
 
-    public componentDidMount(): void {
-        messenger.onRequest(setOptionsType, options => this.setOptions(options));
-        messenger.onNotification(memoryWrittenType, writtenMemory => this.memoryWritten(writtenMemory));
-        messenger.onNotification(sessionContextChangedType, sessionContext => this.sessionContextChanged(sessionContext));
-        messenger.onNotification(setMemoryViewSettingsType, config => {
-            if (config.visibleColumns) {
-                for (const column of columnContributionService.getColumns()) {
-                    const id = column.contribution.id;
-                    const configurable = column.configurable;
-                    this.toggleColumn(id, !configurable || config.visibleColumns.includes(id));
-                }
-            }
-            this.setState(prevState => ({ ...prevState, ...config, title: config.title ?? prevState.title, }));
-        });
-        messenger.onRequest(getWebviewSelectionType, () => this.getWebviewSelection());
-        messenger.onNotification(showAdvancedOptionsType, () => this.showAdvancedOptions());
-        messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
-        breakpointService.init();
-        breakpointService.onDidChange(() => this.forceUpdate());
-        this.updatePeriodicRefresh();
-    }
-
-    public componentDidUpdate(_: {}, from: MemoryAppState): void {
-        const current = this.state;
-        const stateChange: Change<MemoryAppState> = { from, to: current };
-        const sessionContextChange: Change<SessionContext> = { from: from.sessionContext, to: current.sessionContext };
-
-        if (hasChanged(stateChange, 'addressPadding') || (this.state.addressPadding === 'Minimal' && hasChanged(stateChange, 'memory'))) {
-            const effectiveAddressLength = this.getEffectiveAddressLength(this.state.memory);
-            if (this.state.effectiveAddressLength !== effectiveAddressLength) {
-                this.setState({ effectiveAddressLength });
-            }
+  public componentDidMount(): void {
+    messenger.onRequest(setOptionsType, (options) => this.setOptions(options));
+    messenger.onNotification(memoryWrittenType, (writtenMemory) =>
+      this.memoryWritten(writtenMemory)
+    );
+    messenger.onNotification(sessionContextChangedType, (sessionContext) =>
+      this.sessionContextChanged(sessionContext)
+    );
+    messenger.onNotification(setMemoryViewSettingsType, (config) => {
+      if (config.visibleColumns) {
+        for (const column of columnContributionService.getColumns()) {
+          const id = column.contribution.id;
+          const configurable = column.configurable;
+          this.toggleColumn(
+            id,
+            !configurable || config.visibleColumns.includes(id)
+          );
         }
-        if (hasChanged(stateChange, 'periodicRefresh') || hasChanged(stateChange, 'periodicRefreshInterval') || hasChanged(sessionContextChange, 'stopped')) {
-            this.updatePeriodicRefresh();
-        }
+      }
+      this.setState((prevState) => ({
+        ...prevState,
+        ...config,
+        title: config.title ?? prevState.title,
+      }));
+    });
+    messenger.onRequest(getWebviewSelectionType, () =>
+      this.getWebviewSelection()
+    );
+    messenger.onNotification(showAdvancedOptionsType, () =>
+      this.showAdvancedOptions()
+    );
+    messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
+    breakpointService.activate();
+    breakpointService.onDidChange(() => this.forceUpdate());
+    this.updatePeriodicRefresh();
+  }
 
-        if (current.refreshOnStop === 'on' && hasChangedTo(sessionContextChange, 'stopped', true)) {
-            this.fetchMemory();
-        }
-
-        hoverService.setMemoryState(this.state);
-    }
-
-    componentWillUnmount(): void {
-        clearTimeout(this.refreshTimer);
-    }
-
-    protected updatePeriodicRefresh = (): void => {
-        clearTimeout(this.refreshTimer);
-
-        if (this.state.periodicRefreshInterval && this.state.periodicRefreshInterval > 0 &&
-            this.state.periodicRefresh === 'always' || (this.state.periodicRefresh === 'while running' && !this.state.sessionContext.stopped)) {
-            // we do not use an interval here as we only want to schedule another refresh AFTER the previous execution AND the delay has passed
-            // and not strictly every n milliseconds. Even if 'fetchMemory' fails here, we schedule another auto-refresh.
-            const scheduleRefresh = () => this.fetchMemory().finally(() => this.updatePeriodicRefresh());
-            this.refreshTimer = setTimeout(scheduleRefresh, this.state.periodicRefreshInterval);
-        }
+  public componentDidUpdate(_: {}, from: MemoryAppState): void {
+    const current = this.state;
+    const stateChange: Change<MemoryAppState> = { from, to: current };
+    const sessionContextChange: Change<SessionContext> = {
+      from: from.sessionContext,
+      to: current.sessionContext,
     };
 
-    // use a slight debounce as the same event may come in short succession
-    protected memoryWritten = debounce((writtenMemory: WrittenMemory): void => {
-        if (!this.state.memory) {
-            return;
-        }
-        if (this.state.activeReadArguments.memoryReference === writtenMemory.memoryReference) {
-            // catch simple case
-            this.fetchMemory();
-            return;
-        }
-        try {
-            // If we are dealing with numeric addresses (and not expressions) then we can determine the overlap.
-            // Note that we use big int arithmetic here to determine the overlap for (start address + length) vs (memory state address + length), i.e.,
-            // we do not actually determine the end address may need to consider the size of a MAU in bytes
-            const written: BigIntMemoryRange = {
-                startAddress: BigInt(writtenMemory.memoryReference),
-                endAddress: BigInt(writtenMemory.memoryReference) + BigInt(writtenMemory.count ?? 0)
-            };
-            const shown: BigIntMemoryRange = {
-                startAddress: this.state.memory.address,
-                endAddress: this.state.memory.address + BigInt(this.state.memory.bytes.length)
-            };
-            if (doOverlap(written, shown)) {
-                this.fetchMemory();
-                return;
-            }
-        } catch (error) {
-            // ignore and fall through
-        }
+    if (
+      hasChanged(stateChange, "addressPadding") ||
+      (this.state.addressPadding === "Minimal" &&
+        hasChanged(stateChange, "memory"))
+    ) {
+      const effectiveAddressLength = this.getEffectiveAddressLength(
+        this.state.memory
+      );
+      if (this.state.effectiveAddressLength !== effectiveAddressLength) {
+        this.setState({ effectiveAddressLength });
+      }
+    }
+    if (
+      hasChanged(stateChange, "periodicRefresh") ||
+      hasChanged(stateChange, "periodicRefreshInterval") ||
+      hasChanged(sessionContextChange, "stopped")
+    ) {
+      this.updatePeriodicRefresh();
+    }
 
-        // we could try to convert any expression we may have to an address by sending an evaluation request to the DA
-        // but for now we just go with a pessimistic approach: if we are unsure, we refresh the memory
+    if (
+      current.refreshOnStop === "on" &&
+      hasChangedTo(sessionContextChange, "stopped", true)
+    ) {
+      this.fetchMemory();
+    }
+
+    hoverService.setMemoryState(this.state);
+  }
+
+  componentWillUnmount(): void {
+    clearTimeout(this.refreshTimer);
+  }
+
+  protected updatePeriodicRefresh = (): void => {
+    clearTimeout(this.refreshTimer);
+
+    if (
+      (this.state.periodicRefreshInterval &&
+        this.state.periodicRefreshInterval > 0 &&
+        this.state.periodicRefresh === "always") ||
+      (this.state.periodicRefresh === "while running" &&
+        !this.state.sessionContext.stopped)
+    ) {
+      // we do not use an interval here as we only want to schedule another refresh AFTER the previous execution AND the delay has passed
+      // and not strictly every n milliseconds. Even if 'fetchMemory' fails here, we schedule another auto-refresh.
+      const scheduleRefresh = () =>
+        this.fetchMemory().finally(() => this.updatePeriodicRefresh());
+      this.refreshTimer = setTimeout(
+        scheduleRefresh,
+        this.state.periodicRefreshInterval
+      );
+    }
+  };
+
+  // use a slight debounce as the same event may come in short succession
+  protected memoryWritten = debounce((writtenMemory: WrittenMemory): void => {
+    if (!this.state.memory) {
+      return;
+    }
+    if (
+      this.state.activeReadArguments.memoryReference ===
+      writtenMemory.memoryReference
+    ) {
+      // catch simple case
+      this.fetchMemory();
+      return;
+    }
+    try {
+      // If we are dealing with numeric addresses (and not expressions) then we can determine the overlap.
+      // Note that we use big int arithmetic here to determine the overlap for (start address + length) vs (memory state address + length), i.e.,
+      // we do not actually determine the end address may need to consider the size of a MAU in bytes
+      const written: BigIntMemoryRange = {
+        startAddress: BigInt(writtenMemory.memoryReference),
+        endAddress:
+          BigInt(writtenMemory.memoryReference) +
+          BigInt(writtenMemory.count ?? 0),
+      };
+      const shown: BigIntMemoryRange = {
+        startAddress: this.state.memory.address,
+        endAddress:
+          this.state.memory.address + BigInt(this.state.memory.bytes.length),
+      };
+      if (doOverlap(written, shown)) {
         this.fetchMemory();
-    }, 100);
-
-    protected sessionContextChanged(sessionContext: SessionContext): void {
-        this.setState({ sessionContext });
+        return;
+      }
+    } catch (error) {
+      // ignore and fall through
     }
 
-    public render(): React.ReactNode {
-        return <PrimeReactProvider>
-            <MemoryWidget
-                ref={this.memoryWidget}
-                messageParticipant={this.state.messageParticipant}
-                sessionContext={this.state.sessionContext}
-                configuredReadArguments={this.state.configuredReadArguments}
-                activeReadArguments={this.state.activeReadArguments}
-                memory={this.state.memory}
-                decorations={this.state.decorations}
-                hoverService={this.state.hoverService}
-                columns={this.state.columns}
-                title={this.state.title}
-                effectiveAddressLength={this.state.effectiveAddressLength}
-                updateMemoryState={this.updateMemoryState}
-                updateMemoryDisplayConfiguration={this.updateMemoryDisplayConfiguration}
-                resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
-                updateTitle={this.updateTitle}
-                toggleColumn={this.toggleColumn}
-                toggleFrozen={this.toggleFrozen}
-                isFrozen={this.state.isFrozen}
-                fetchMemory={this.fetchMemory}
-                isMemoryFetching={this.state.isMemoryFetching}
-                bytesPerMau={this.state.bytesPerMau}
-                groupsPerRow={this.state.groupsPerRow}
-                endianness={this.state.endianness}
-                mausPerGroup={this.state.mausPerGroup}
-                scrollingBehavior={this.state.scrollingBehavior}
-                addressPadding={this.state.addressPadding}
-                addressRadix={this.state.addressRadix}
-                showRadixPrefix={this.state.showRadixPrefix}
-                storeMemory={this.storeMemory}
-                applyMemory={this.applyMemory}
-                refreshOnStop={this.state.refreshOnStop}
-                periodicRefresh={this.state.periodicRefresh}
-                periodicRefreshInterval={this.state.periodicRefreshInterval}
-            />
-        </PrimeReactProvider>;
+    // we could try to convert any expression we may have to an address by sending an evaluation request to the DA
+    // but for now we just go with a pessimistic approach: if we are unsure, we refresh the memory
+    this.fetchMemory();
+  }, 100);
+
+  protected sessionContextChanged(sessionContext: SessionContext): void {
+    this.setState({ sessionContext });
+  }
+
+  public render(): React.ReactNode {
+    return (
+      <PrimeReactProvider>
+        <MemoryWidget
+          ref={this.memoryWidget}
+          messageParticipant={this.state.messageParticipant}
+          sessionContext={this.state.sessionContext}
+          configuredReadArguments={this.state.configuredReadArguments}
+          activeReadArguments={this.state.activeReadArguments}
+          memory={this.state.memory}
+          decorations={this.state.decorations}
+          hoverService={this.state.hoverService}
+          columns={this.state.columns}
+          title={this.state.title}
+          effectiveAddressLength={this.state.effectiveAddressLength}
+          updateMemoryState={this.updateMemoryState}
+          updateMemoryDisplayConfiguration={
+            this.updateMemoryDisplayConfiguration
+          }
+          resetMemoryDisplayConfiguration={this.resetMemoryDisplayConfiguration}
+          updateTitle={this.updateTitle}
+          toggleColumn={this.toggleColumn}
+          toggleFrozen={this.toggleFrozen}
+          isFrozen={this.state.isFrozen}
+          fetchMemory={this.fetchMemory}
+          isMemoryFetching={this.state.isMemoryFetching}
+          bytesPerMau={this.state.bytesPerMau}
+          groupsPerRow={this.state.groupsPerRow}
+          endianness={this.state.endianness}
+          mausPerGroup={this.state.mausPerGroup}
+          scrollingBehavior={this.state.scrollingBehavior}
+          addressPadding={this.state.addressPadding}
+          addressRadix={this.state.addressRadix}
+          showRadixPrefix={this.state.showRadixPrefix}
+          storeMemory={this.storeMemory}
+          applyMemory={this.applyMemory}
+          refreshOnStop={this.state.refreshOnStop}
+          periodicRefresh={this.state.periodicRefresh}
+          periodicRefreshInterval={this.state.periodicRefreshInterval}
+        />
+      </PrimeReactProvider>
+    );
+  }
+
+  protected updateMemoryState = (newState?: Partial<MemoryState>) =>
+    this.setState((prevState) => ({ ...prevState, ...newState }));
+  protected updateMemoryDisplayConfiguration = (
+    newState: Partial<MemoryDisplayConfiguration>
+  ) => this.setState((prevState) => ({ ...prevState, ...newState }));
+  protected resetMemoryDisplayConfiguration = () =>
+    messenger.sendNotification(
+      resetMemoryViewSettingsType,
+      HOST_EXTENSION,
+      undefined
+    );
+
+  protected updateTitle = (title: string) => {
+    this.setState({ title });
+    messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
+  };
+
+  protected async setOptions(options?: MemoryOptions): Promise<void> {
+    messenger.sendRequest(
+      logMessageType,
+      HOST_EXTENSION,
+      `Setting options: ${JSON.stringify(options)}`
+    );
+    this.setState({
+      configuredReadArguments: {
+        ...this.state.configuredReadArguments,
+        ...options,
+      },
+    });
+    return this.fetchMemory(options);
+  }
+
+  protected fetchMemory = async (
+    partialOptions?: MemoryOptions
+  ): Promise<void> => {
+    if (this.state.isFrozen || !this.state.sessionContext.canRead) {
+      return;
     }
-
-    protected updateMemoryState = (newState?: Partial<MemoryState>) => this.setState(prevState => ({ ...prevState, ...newState }));
-    protected updateMemoryDisplayConfiguration = (newState: Partial<MemoryDisplayConfiguration>) => this.setState(prevState => ({ ...prevState, ...newState }));
-    protected resetMemoryDisplayConfiguration = () => messenger.sendNotification(resetMemoryViewSettingsType, HOST_EXTENSION, undefined);
-
-    protected updateTitle = (title: string) => {
-        this.setState({ title });
-        messenger.sendNotification(setTitleType, HOST_EXTENSION, title);
+    const completeOptions = {
+      memoryReference:
+        partialOptions?.memoryReference ||
+        this.state.activeReadArguments.memoryReference,
+      offset: partialOptions?.offset ?? this.state.activeReadArguments.offset,
+      count: partialOptions?.count ?? this.state.activeReadArguments.count,
     };
-
-    protected async setOptions(options?: MemoryOptions): Promise<void> {
-        messenger.sendRequest(logMessageType, HOST_EXTENSION, `Setting options: ${JSON.stringify(options)}`);
-        this.setState({ configuredReadArguments: { ...this.state.configuredReadArguments, ...options } });
-        return this.fetchMemory(options);
+    // Don't fetch memory if we have an incomplete memory reference
+    if (completeOptions.memoryReference === "") {
+      return;
     }
+    return this.doFetchMemory(completeOptions);
+  };
 
-    protected fetchMemory = async (partialOptions?: MemoryOptions): Promise<void> => {
-        if (this.state.isFrozen || !this.state.sessionContext.canRead) {
-            return;
-        }
-        const completeOptions = {
-            memoryReference: partialOptions?.memoryReference || this.state.activeReadArguments.memoryReference,
-            offset: partialOptions?.offset ?? this.state.activeReadArguments.offset,
-            count: partialOptions?.count ?? this.state.activeReadArguments.count
-        };
-        // Don't fetch memory if we have an incomplete memory reference
-        if (completeOptions.memoryReference === '') {
-            return;
-        }
-        return this.doFetchMemory(completeOptions);
-    };
+  protected async doFetchMemory(
+    memoryOptions: Required<MemoryOptions>
+  ): Promise<void> {
+    this.setState({
+      isMemoryFetching: true,
+      activeReadArguments: memoryOptions,
+    });
 
-    protected async doFetchMemory(memoryOptions: Required<MemoryOptions>): Promise<void> {
-        this.setState({ isMemoryFetching: true, activeReadArguments: memoryOptions });
+    try {
+      const response = await messenger.sendRequest(
+        readMemoryType,
+        HOST_EXTENSION,
+        memoryOptions
+      );
+      await Promise.all(
+        Array.from(
+          new Set(
+            columnContributionService
+              .getUpdateExecutors()
+              .concat(decorationService.getUpdateExecutors())
+              .concat(breakpointService)
+          ),
+          (executor) => executor.fetchData(memoryOptions)
+        )
+      );
 
-        try {
-            const response = await messenger.sendRequest(readMemoryType, HOST_EXTENSION, memoryOptions);
-            await Promise.all(Array.from(
-                new Set(columnContributionService
-                    .getUpdateExecutors()
-                    .concat(decorationService.getUpdateExecutors())
-                    .concat(breakpointService)),
-                executor => executor.fetchData(memoryOptions)
-            ));
+      const memory = createMemoryFromRead(response);
+      this.setState({ memory, decorations: decorationService.decorations });
+      messenger.sendRequest(setOptionsType, HOST_EXTENSION, memoryOptions);
+    } catch (ex) {
+      // Do not show old results if the current search provided no memory
+      this.setState({ memory: undefined });
 
-            const memory = createMemoryFromRead(response);
-            this.setState({ memory, decorations: decorationService.decorations });
-            messenger.sendRequest(setOptionsType, HOST_EXTENSION, memoryOptions);
-        } catch (ex) {
-            // Do not show old results if the current search provided no memory
-            this.setState({ memory: undefined });
-
-            if (ex instanceof Error) {
-                console.error(ex);
-            }
-        } finally {
-            this.setState({ isMemoryFetching: false });
-        }
+      if (ex instanceof Error) {
+        console.error(ex);
+      }
+    } finally {
+      this.setState({ isMemoryFetching: false });
     }
+  }
 
-    protected getEffectiveAddressLength(memory?: Memory): number {
-        const { addressRadix, addressPadding } = this.state;
-        return addressPadding === 'Minimal' ? this.getLastAddressLength(memory) : getAddressLength(addressPadding, addressRadix);
+  protected getEffectiveAddressLength(memory?: Memory): number {
+    const { addressRadix, addressPadding } = this.state;
+    return addressPadding === "Minimal"
+      ? this.getLastAddressLength(memory)
+      : getAddressLength(addressPadding, addressRadix);
+  }
+
+  protected getLastAddressLength(memory?: Memory): number {
+    if (memory === undefined || this.state.groupsPerRow === "Autofit") {
+      return 0;
     }
+    const rowLength =
+      this.state.bytesPerMau *
+      this.state.mausPerGroup *
+      this.state.groupsPerRow;
+    const rows = Math.ceil(memory.bytes.length / rowLength);
+    const finalAddress = memory.address + BigInt((rows - 1) * rowLength);
+    return getAddressString(finalAddress, this.state.addressRadix).length;
+  }
 
-    protected getLastAddressLength(memory?: Memory): number {
-        if (memory === undefined || this.state.groupsPerRow === 'Autofit') {
-            return 0;
-        }
-        const rowLength = this.state.bytesPerMau * this.state.mausPerGroup * this.state.groupsPerRow;
-        const rows = Math.ceil(memory.bytes.length / rowLength);
-        const finalAddress = memory.address + BigInt(((rows - 1) * rowLength));
-        return getAddressString(finalAddress, this.state.addressRadix).length;
-    }
+  protected toggleColumn = (id: string, active: boolean): void => {
+    this.doToggleColumn(id, active);
+  };
+  protected async doToggleColumn(
+    id: string,
+    isVisible: boolean
+  ): Promise<void> {
+    const columns = isVisible
+      ? await columnContributionService.show(id, this.state)
+      : columnContributionService.hide(id);
+    this.setState({ columns });
+  }
 
-    protected toggleColumn = (id: string, active: boolean): void => { this.doToggleColumn(id, active); };
-    protected async doToggleColumn(id: string, isVisible: boolean): Promise<void> {
-        const columns = isVisible ? await columnContributionService.show(id, this.state) : columnContributionService.hide(id);
-        this.setState({ columns });
-    }
+  protected toggleFrozen = (): void => {
+    this.doToggleFrozen();
+  };
+  protected doToggleFrozen(): void {
+    this.setState((prevState) => ({ isFrozen: !prevState.isFrozen }));
+  }
 
-    protected toggleFrozen = (): void => { this.doToggleFrozen(); };
-    protected doToggleFrozen(): void {
-        this.setState(prevState => ({ isFrozen: !prevState.isFrozen }));
-    }
+  protected showAdvancedOptions(): void {
+    this.memoryWidget.current?.showAdvancedOptions();
+  }
 
-    protected showAdvancedOptions(): void {
-        this.memoryWidget.current?.showAdvancedOptions();
-    }
+  protected getWebviewSelection(): WebviewSelection {
+    return this.memoryWidget.current?.getWebviewSelection() ?? {};
+  }
 
-    protected getWebviewSelection(): WebviewSelection {
-        return this.memoryWidget.current?.getWebviewSelection() ?? {};
-    }
+  protected storeMemory = async (): Promise<void> => {
+    await messenger.sendRequest(storeMemoryType, HOST_EXTENSION, {
+      ...this.state.activeReadArguments,
+    });
+  };
 
-    protected storeMemory = async (): Promise<void> => {
-        await messenger.sendRequest(storeMemoryType, HOST_EXTENSION, { ...this.state.activeReadArguments });
-    };
-
-    protected applyMemory = async (): Promise<void> => {
-        await messenger.sendRequest(applyMemoryType, HOST_EXTENSION, undefined);
-    };
+  protected applyMemory = async (): Promise<void> => {
+    await messenger.sendRequest(applyMemoryType, HOST_EXTENSION, undefined);
+  };
 }
 
-const container = document.getElementById('root') as Element;
+const container = document.getElementById("root") as Element;
 createRoot(container).render(<App />);

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -35,7 +35,6 @@ import {
     resetMemoryViewSettingsType,
     SessionContext,
     sessionContextChangedType,
-    setDataBreakpointType,
     setMemoryViewSettingsType,
     setOptionsType,
     setTitleType,
@@ -138,10 +137,8 @@ class App extends React.Component<{}, MemoryAppState> {
         messenger.onRequest(getWebviewSelectionType, () => this.getWebviewSelection());
         messenger.onNotification(showAdvancedOptionsType, () => this.showAdvancedOptions());
         messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
-        messenger.onNotification(setDataBreakpointType, breakpoints => {
-            breakpointService.update(breakpoints);
-            this.forceUpdate();
-        });
+        breakpointService.init();
+        breakpointService.onDidChange(() => this.forceUpdate());
         this.updatePeriodicRefresh();
     }
 
@@ -299,7 +296,10 @@ class App extends React.Component<{}, MemoryAppState> {
         try {
             const response = await messenger.sendRequest(readMemoryType, HOST_EXTENSION, memoryOptions);
             await Promise.all(Array.from(
-                new Set(columnContributionService.getUpdateExecutors().concat(decorationService.getUpdateExecutors())),
+                new Set(columnContributionService
+                    .getUpdateExecutors()
+                    .concat(decorationService.getUpdateExecutors())
+                    .concat(breakpointService)),
                 executor => executor.fetchData(memoryOptions)
             ));
 

--- a/src/webview/memory-webview-view.tsx
+++ b/src/webview/memory-webview-view.tsx
@@ -35,6 +35,7 @@ import {
     resetMemoryViewSettingsType,
     SessionContext,
     sessionContextChangedType,
+    setDataBreakpointType,
     setMemoryViewSettingsType,
     setOptionsType,
     setTitleType,
@@ -44,6 +45,7 @@ import {
 } from '../common/messaging';
 import { Change, hasChanged, hasChangedTo } from '../common/typescript';
 import { MemoryDisplayConfiguration } from '../common/webview-configuration';
+import { breakpointService } from './breakpoints/breakpoint-service';
 import { AddressColumn } from './columns/address-column';
 import { AsciiColumn } from './columns/ascii-column';
 import { columnContributionService, ColumnStatus } from './columns/column-contribution-service';
@@ -136,6 +138,10 @@ class App extends React.Component<{}, MemoryAppState> {
         messenger.onRequest(getWebviewSelectionType, () => this.getWebviewSelection());
         messenger.onNotification(showAdvancedOptionsType, () => this.showAdvancedOptions());
         messenger.sendNotification(readyType, HOST_EXTENSION, undefined);
+        messenger.onNotification(setDataBreakpointType, breakpoints => {
+            breakpointService.update(breakpoints);
+            this.forceUpdate();
+        });
         this.updatePeriodicRefresh();
     }
 

--- a/src/webview/utils/vscode-contexts.ts
+++ b/src/webview/utils/vscode-contexts.ts
@@ -28,7 +28,7 @@ export interface VscodeContext {
 export type WebviewSection = 'optionsWidget' | 'advancedOptionsOverlay' | 'memoryTable';
 
 export function createVscodeContext<C extends {}>(context: C): VscodeContext {
-    return { 'data-vscode-context': JSON.stringify(includeFlatKeys(context)) };
+    return { 'data-vscode-context': JSON.stringify(includeFlatKeys(context), replacerForBigInt) };
 }
 
 function includeFlatKeys(src: object): Record<string, unknown> {
@@ -60,8 +60,19 @@ export function createAppVscodeContext(context: Omit<WebviewContext, 'webviewSec
     return createVscodeContext({ ...context, webviewSection: 'app', preventDefaultContextMenuItems: true });
 }
 
+export function createGroupVscodeContext(startAddress: BigInt, length: number): VscodeContext {
+    return createVscodeContext({ memoryData: { group: { startAddress, length } } });
+}
+
 export function createVariableVscodeContext(variable: BigIntVariableRange): VscodeContext {
     const { name, type, value, isPointer } = variable;
     return createVscodeContext({ variable: { name, type, value, isPointer } });
+}
+
+function replacerForBigInt(_: string, value: unknown): unknown {
+    if (typeof value === 'bigint') {
+        return `0x${value.toString(16)}`;
+    }
+    return value;
 }
 

--- a/src/webview/utils/vscode-contexts.ts
+++ b/src/webview/utils/vscode-contexts.ts
@@ -66,8 +66,8 @@ export function createGroupVscodeContext(startAddress: bigint, length: number, b
 }
 
 export function createVariableVscodeContext(variable: BigIntVariableRange, breakpoint?: BreakpointMetadata): VscodeContext {
-    const { name, type, value, isPointer } = variable;
-    return createVscodeContext({ variable: { name, type, value, isPointer }, breakpoint: { ...breakpoint, isBreakable: true } });
+    const { name, type, value, parentVariablesReference, isPointer } = variable;
+    return createVscodeContext({ variable: { name, type, value, parentVariablesReference, isPointer }, breakpoint: { ...breakpoint, isBreakable: true } });
 }
 
 function replacerForBigInt(_: string, value: unknown): unknown {

--- a/src/webview/utils/vscode-contexts.ts
+++ b/src/webview/utils/vscode-contexts.ts
@@ -16,6 +16,7 @@
 
 import { BigIntVariableRange } from '../../common/memory-range';
 import { WebviewContext } from '../../common/webview-context';
+import { BreakpointMetadata } from '../breakpoints/breakpoint-service';
 /**
  * Custom data property used by VSCode to provide additional context info when opening a webview context menu
  * The data property needs to represent a valid JSON object.  Data context properties up the parent chain are merged into the child context.
@@ -60,13 +61,13 @@ export function createAppVscodeContext(context: Omit<WebviewContext, 'webviewSec
     return createVscodeContext({ ...context, webviewSection: 'app', preventDefaultContextMenuItems: true });
 }
 
-export function createGroupVscodeContext(startAddress: BigInt, length: number): VscodeContext {
-    return createVscodeContext({ memoryData: { group: { startAddress, length } } });
+export function createGroupVscodeContext(startAddress: bigint, length: number, breakpoint?: BreakpointMetadata): VscodeContext {
+    return createVscodeContext({ memoryData: { group: { startAddress, length } }, breakpoint: { ...breakpoint, isBreakable: true } });
 }
 
-export function createVariableVscodeContext(variable: BigIntVariableRange): VscodeContext {
+export function createVariableVscodeContext(variable: BigIntVariableRange, breakpoint?: BreakpointMetadata): VscodeContext {
     const { name, type, value, isPointer } = variable;
-    return createVscodeContext({ variable: { name, type, value, isPointer } });
+    return createVscodeContext({ variable: { name, type, value, isPointer }, breakpoint: { ...breakpoint, isBreakable: true } });
 }
 
 function replacerForBigInt(_: string, value: unknown): unknown {

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { classNames } from 'primereact/utils';
 import { ReactNode } from 'react';
 import * as React from 'react';
 import { HOST_EXTENSION } from 'vscode-messenger-common';
 import { areVariablesEqual, BigIntMemoryRange, BigIntVariableRange, compareBigInt, doOverlap } from '../../common/memory-range';
 import { getVariablesType, ReadMemoryArguments } from '../../common/messaging';
 import { stringifyWithBigInts } from '../../common/typescript';
+import { breakpointClassNames, breakpointService } from '../breakpoints/breakpoint-service';
 import { ColumnContribution } from '../columns/column-contribution-service';
 import { Decorator } from '../decorations/decoration-service';
 import { EventEmitter, IEvent } from '../utils/events';
@@ -80,13 +82,14 @@ export class VariableDecorator implements ColumnContribution, Decorator {
     render(range: BigIntMemoryRange): ReactNode {
         return this.getVariablesInRange(range)?.reduce<ReactNode[]>((result, current, index) => {
             if (index > 0) { result.push(', '); }
+            const breakpointMetadata = breakpointService.metadata(current.variable.name);
             result.push(React.createElement('span', {
                 style: { color: current.color },
                 key: current.variable.name,
-                className: 'hoverable',
+                className: classNames('hoverable', ...breakpointClassNames(breakpointMetadata)),
                 'data-column': 'variables',
                 'data-variables': stringifyWithBigInts(current.variable),
-                ...createVariableVscodeContext(current.variable)
+                ...createVariableVscodeContext(current.variable, breakpointMetadata)
             }, current.variable.name));
             return result;
         }, []);

--- a/src/webview/variables/variable-decorations.ts
+++ b/src/webview/variables/variable-decorations.ts
@@ -21,7 +21,7 @@ import { HOST_EXTENSION } from 'vscode-messenger-common';
 import { areVariablesEqual, BigIntMemoryRange, BigIntVariableRange, compareBigInt, doOverlap } from '../../common/memory-range';
 import { getVariablesType, ReadMemoryArguments } from '../../common/messaging';
 import { stringifyWithBigInts } from '../../common/typescript';
-import { breakpointClassNames, breakpointService } from '../breakpoints/breakpoint-service';
+import { BreakpointService, breakpointService } from '../breakpoints/breakpoint-service';
 import { ColumnContribution } from '../columns/column-contribution-service';
 import { Decorator } from '../decorations/decoration-service';
 import { EventEmitter, IEvent } from '../utils/events';
@@ -86,7 +86,7 @@ export class VariableDecorator implements ColumnContribution, Decorator {
             result.push(React.createElement('span', {
                 style: { color: current.color },
                 key: current.variable.name,
-                className: classNames('hoverable', ...breakpointClassNames(breakpointMetadata)),
+                className: classNames('hoverable', ...BreakpointService.inlineClasses(breakpointMetadata)),
                 'data-column': 'variables',
                 'data-variables': stringifyWithBigInts(current.variable),
                 ...createVariableVscodeContext(current.variable, breakpointMetadata)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md
-->

# PROTOTYPE DEMONSTRATION

#### What it does
Allows to set data breakpoints within the memory table.

https://github.com/eclipsesource/vscode-memory-inspector/assets/13104167/44131d4e-a5e8-4d9b-bf98-a3ee7cc5c5d9

#### Important

The VSCode extension API does not support creating Data Breakpoints directly through their API. The method [extHostDebugService.ts#addBreakpoints](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostDebugService.ts#L412) currently lacks the ability to forward data breakpoints (i.e., missing DTOs), while [MainThreadDebugService.ts#$registerBreakpoints](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/browser/mainThreadDebugService.ts#L210) already supports it. However, we only have access to the extension API which uses the extHostDebugService internally. That means, we don't have a way to tell VSCode to show new Data Breakpoints within their UI! Consequently, we need to manually track our breakpoints.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the debugger
2. Open the memory inspector
3. Set data-breakpoints through the context menu for variables and groups. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the contribution guidelines](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CONTRIBUTING.md)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the code of conduct](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/blob/main/CODE_OF_CONDUCT.md)
